### PR TITLE
Epicflare template updates

### DIFF
--- a/client/client-routes.tsx
+++ b/client/client-routes.tsx
@@ -15,6 +15,19 @@ import {
 	typography,
 } from './styles/tokens.ts'
 
+function getSearchParams() {
+	return typeof window === 'undefined'
+		? new URLSearchParams()
+		: new URLSearchParams(window.location.search)
+}
+
+function normalizeRedirectTo(value: string | null) {
+	if (!value) return null
+	if (!value.startsWith('/')) return null
+	if (value.startsWith('//')) return null
+	return value
+}
+
 export function HomeRoute() {
 	return (_match: { path: string; params: Record<string, string> }) => (
 		<section
@@ -79,15 +92,27 @@ export function HomeRoute() {
 
 type AuthMode = 'login' | 'signup'
 type AuthStatus = 'idle' | 'submitting' | 'success' | 'error'
+type AccountStatus = 'idle' | 'loading' | 'ready' | 'error'
 
 type LoginFormSetup = {
 	initialMode?: AuthMode
+}
+
+function buildAuthPath(mode: AuthMode, redirectTo: string | null) {
+	const path = mode === 'signup' ? '/signup' : '/login'
+	if (!redirectTo) return path
+	const params = new URLSearchParams({ redirectTo })
+	return `${path}?${params.toString()}`
 }
 
 function LoginForm(handle: Handle, setup: LoginFormSetup = {}) {
 	let mode: AuthMode = setup.initialMode ?? 'login'
 	let status: AuthStatus = 'idle'
 	let message: string | null = null
+	let sessionStatus: SessionStatus = 'idle'
+	let sessionEmail = ''
+	const redirectTo = normalizeRedirectTo(getSearchParams().get('redirectTo'))
+	const redirectTarget = redirectTo ?? '/account'
 
 	function setState(nextStatus: AuthStatus, nextMessage: string | null = null) {
 		status = nextStatus
@@ -100,19 +125,25 @@ function LoginForm(handle: Handle, setup: LoginFormSetup = {}) {
 		mode = nextMode
 		status = 'idle'
 		message = null
-		navigate(nextMode === 'signup' ? '/signup' : '/login')
+		navigate(buildAuthPath(nextMode, redirectTo))
 		handle.update()
 	}
 
-	function getRedirectTarget() {
-		if (typeof window === 'undefined') return null
-		const params = new URLSearchParams(window.location.search)
-		const redirectTo = params.get('redirectTo')
-		if (!redirectTo) return null
-		if (!redirectTo.startsWith('/')) return null
-		if (redirectTo.startsWith('//')) return null
-		return redirectTo
-	}
+	handle.queueTask(async (signal) => {
+		if (sessionStatus !== 'idle') return
+		sessionStatus = 'loading'
+
+		const session = await fetchSessionInfo(signal)
+		if (signal.aborted) return
+		sessionEmail = session?.email ?? ''
+
+		sessionStatus = 'ready'
+		if (sessionEmail && typeof window !== 'undefined') {
+			window.location.assign(redirectTarget)
+			return
+		}
+		handle.update()
+	})
 
 	async function handleSubmit(event: SubmitEvent) {
 		event.preventDefault()
@@ -148,8 +179,7 @@ function LoginForm(handle: Handle, setup: LoginFormSetup = {}) {
 			}
 
 			if (typeof window !== 'undefined') {
-				const redirectTo = getRedirectTarget()
-				window.location.assign(redirectTo ?? '/account')
+				window.location.assign(redirectTarget)
 			}
 		} catch {
 			setState('error', 'Network error. Please try again.')
@@ -297,7 +327,7 @@ function LoginForm(handle: Handle, setup: LoginFormSetup = {}) {
 				</form>
 				<div css={{ display: 'grid', gap: spacing.sm }}>
 					<a
-						href={isSignup ? '/login' : '/signup'}
+						href={buildAuthPath(isSignup ? 'login' : 'signup', redirectTo)}
 						aria-pressed={isSignup}
 						on={{
 							click: (event) => {
@@ -346,6 +376,90 @@ export function LoginRoute(initialMode: AuthMode = 'login') {
 	)
 }
 
+function AccountPage(handle: Handle) {
+	let status: AccountStatus = 'loading'
+	let email = ''
+	let message: string | null = null
+
+	async function loadAccount(signal: AbortSignal) {
+		try {
+			const response = await fetch('/session', {
+				headers: { Accept: 'application/json' },
+				credentials: 'include',
+				signal,
+			})
+			if (signal.aborted) return
+			const payload = await response.json().catch(() => null)
+			const sessionEmail =
+				response.ok &&
+				payload?.ok &&
+				typeof payload?.session?.email === 'string'
+					? payload.session.email.trim()
+					: ''
+			if (!sessionEmail) {
+				window.location.assign('/login')
+				return
+			}
+			email = sessionEmail
+			status = 'ready'
+			message = null
+			handle.update()
+		} catch {
+			if (signal.aborted) return
+			status = 'error'
+			message = 'Unable to load your account.'
+			handle.update()
+		}
+	}
+
+	return () => {
+		if (status === 'loading') {
+			handle.queueTask(loadAccount)
+		}
+
+		return (
+			<section
+				css={{
+					maxWidth: '28rem',
+					margin: '0 auto',
+					display: 'grid',
+					gap: spacing.lg,
+				}}
+			>
+				<header css={{ display: 'grid', gap: spacing.xs }}>
+					<h1
+						css={{
+							fontSize: typography.fontSize.xl,
+							fontWeight: typography.fontWeight.semibold,
+							color: colors.text,
+							margin: 0,
+						}}
+					>
+						{email ? `Welcome, ${email}` : 'Welcome'}
+					</h1>
+					<p css={{ color: colors.textMuted }}>
+						You are signed in to epicflare.
+					</p>
+				</header>
+				{status === 'loading' ? (
+					<p css={{ color: colors.textMuted }}>Loading your account…</p>
+				) : null}
+				{message ? (
+					<p css={{ color: colors.error }} role="alert">
+						{message}
+					</p>
+				) : null}
+			</section>
+		)
+	}
+}
+
+export function AccountRoute() {
+	return (_match: { path: string; params: Record<string, string> }) => (
+		<AccountPage />
+	)
+}
+
 type OAuthAuthorizeInfo = {
 	client: { id: string; name: string }
 	scopes: Array<string>
@@ -366,12 +480,6 @@ function OAuthAuthorizeForm(handle: Handle) {
 	function setMessage(next: OAuthAuthorizeMessage | null) {
 		message = next
 		handle.update()
-	}
-
-	function getSearchParams() {
-		return typeof window === 'undefined'
-			? new URLSearchParams()
-			: new URLSearchParams(window.location.search)
 	}
 
 	function readQueryError() {

--- a/client/session.ts
+++ b/client/session.ts
@@ -4,12 +4,16 @@ export type SessionInfo = {
 
 export type SessionStatus = 'idle' | 'loading' | 'ready'
 
-export async function fetchSessionInfo(): Promise<SessionInfo | null> {
+export async function fetchSessionInfo(
+	signal?: AbortSignal,
+): Promise<SessionInfo | null> {
 	try {
 		const response = await fetch('/session', {
 			headers: { Accept: 'application/json' },
 			credentials: 'include',
+			signal,
 		})
+		if (signal?.aborted) return null
 		const payload = await response.json().catch(() => null)
 		const email =
 			response.ok && payload?.ok && typeof payload?.session?.email === 'string'

--- a/server/handlers/account.ts
+++ b/server/handlers/account.ts
@@ -1,50 +1,9 @@
 import { type BuildAction } from 'remix/fetch-router'
-import { html } from 'remix/html-template'
 import { readAuthSession } from '../auth-session.ts'
 import { redirectToLogin } from '../auth-redirect.ts'
 import { Layout } from '../layout.ts'
 import { render } from '../render.ts'
 import type routes from '../routes.ts'
-
-function escapeHtml(value: string) {
-	return value
-		.replace(/&/g, '&amp;')
-		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;')
-		.replace(/"/g, '&quot;')
-		.replace(/'/g, '&#39;')
-}
-
-function renderAccount(email: string) {
-	return html`<main
-		style="max-width: 52rem; margin: 0 auto; padding: var(--spacing-page); font-family: var(--font-family);"
-	>
-		<section style="display: grid; gap: var(--spacing-md);">
-			<h1
-				style="font-size: var(--font-size-xl); font-weight: var(--font-weight-semibold); margin: 0;"
-			>
-				Welcome, ${escapeHtml(email)}
-			</h1>
-			<p style="margin: 0; color: var(--color-text-muted);">
-				You are signed in to epicflare.
-			</p>
-			<form method="post" action="/logout" style="margin: 0;">
-				<button
-					type="submit"
-					style="padding: var(--spacing-sm) var(--spacing-lg); border-radius: var(--radius-full); border: none; background: var(--color-primary); color: var(--color-on-primary); font-size: var(--font-size-base); font-weight: var(--font-weight-semibold); cursor: pointer;"
-				>
-					Log out
-				</button>
-			</form>
-			<a
-				href="/"
-				style="color: var(--color-primary); font-weight: var(--font-weight-medium); text-decoration: none;"
-			>
-				Back home
-			</a>
-		</section>
-	</main>`
-}
 
 export default {
 	middleware: [],
@@ -57,9 +16,7 @@ export default {
 
 		return render(
 			Layout({
-				title: 'Welcome',
-				entryScripts: false,
-				children: renderAccount(session.email),
+				title: 'Account',
 			}),
 		)
 	},

--- a/server/handlers/auth-page.ts
+++ b/server/handlers/auth-page.ts
@@ -2,13 +2,25 @@ import { readAuthSession } from '../auth-session.ts'
 import { Layout } from '../layout.ts'
 import { render } from '../render.ts'
 
+function normalizeRedirectTo(value: string | null) {
+	if (!value) return null
+	if (!value.startsWith('/')) return null
+	if (value.startsWith('//')) return null
+	return value
+}
+
 export function createAuthPageHandler() {
 	return {
 		middleware: [],
 		async action({ request }: { request: Request }) {
 			const session = await readAuthSession(request)
 			if (session) {
-				return Response.redirect(new URL('/account', request.url), 302)
+				const url = new URL(request.url)
+				const redirectTo = normalizeRedirectTo(
+					url.searchParams.get('redirectTo'),
+				)
+				const redirectTarget = redirectTo ?? '/account'
+				return Response.redirect(new URL(redirectTarget, request.url), 302)
 			}
 
 			return render(Layout({}))

--- a/server/handlers/logout.ts
+++ b/server/handlers/logout.ts
@@ -2,12 +2,45 @@ import { type BuildAction } from 'remix/fetch-router'
 import { destroyAuthCookie } from '../auth-session.ts'
 import type routes from '../routes.ts'
 
+function normalizeProto(value: string) {
+	return value.trim().replace(/^"|"$/g, '').toLowerCase()
+}
+
+function getForwardedProto(request: Request) {
+	const forwarded = request.headers.get('forwarded')
+	if (forwarded) {
+		for (const entry of forwarded.split(',')) {
+			for (const pair of entry.split(';')) {
+				const [key, rawValue] = pair.split('=')
+				if (!key || !rawValue) continue
+				if (key.trim().toLowerCase() === 'proto') {
+					return normalizeProto(rawValue)
+				}
+			}
+		}
+	}
+
+	const xForwardedProto = request.headers.get('x-forwarded-proto')
+	if (xForwardedProto) {
+		return normalizeProto(xForwardedProto.split(',')[0] ?? '')
+	}
+
+	return null
+}
+
+function isSecureRequest(request: Request) {
+	const forwardedProto = getForwardedProto(request)
+	if (forwardedProto) {
+		return forwardedProto === 'https'
+	}
+	return new URL(request.url).protocol === 'https:'
+}
+
 export default {
 	middleware: [],
 	async action({ request }) {
-		const requestUrl = new URL(request.url)
-		const cookie = await destroyAuthCookie(requestUrl.protocol === 'https:')
-		const location = new URL('/login', requestUrl)
+		const cookie = await destroyAuthCookie(isSecureRequest(request))
+		const location = new URL('/login', request.url)
 
 		return new Response(null, {
 			status: 302,


### PR DESCRIPTION
Implement client-side account page, session-aware navigation, and robust authentication redirects/logout.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-d02fe749-88e3-461d-ba70-ebfa7a434508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d02fe749-88e3-461d-ba70-ebfa7a434508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication-related redirects and logout cookie handling, which can affect session flow and security if misconfigured; overall scope is contained to routing/session UI and handlers.
> 
> **Overview**
> Moves the `/account` experience to the client: adds `AccountRoute`/`AccountPage` that fetches `/session`, redirects to `/login` when unauthenticated, and wires the route into `App`.
> 
> Updates client auth flows to be session-aware and abortable: `fetchSessionInfo` now accepts an `AbortSignal`, `App` loads session via `queueTask` and renders login/signup vs account+logout links accordingly, and login/signup preserve a validated `redirectTo` query param for post-auth redirects.
> 
> Server handlers are simplified/strengthened: `account` no longer renders an HTML account page (just serves the app shell with `title: 'Account'`), `auth-page` redirects signed-in users to a normalized `redirectTo` target when provided, and `logout` now determines cookie “secure” behavior using `Forwarded`/`X-Forwarded-Proto` to work correctly behind proxies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e89d340bb1f2770dde59ced9d7cc812bb8e36793. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->