### PR TITLE
Production deploy visibility

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,19 +9,22 @@ on:
 
 permissions:
   contents: read
+  deployments: write
 
 concurrency:
   group: deploy-production
   cancel-in-progress: true
 
 jobs:
-  deploy:
+  sha-guard:
     runs-on: ubuntu-latest
-    name: 🚀 Deploy to production
+    name: 🧾 Production deploy guard
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.head_branch == 'main' &&
       github.event.workflow_run.event == 'push'
+    outputs:
+      should_deploy: ${{ steps.sha_guard.outputs.should_deploy }}
     steps:
       - name: 📦 Checkout
         uses: actions/checkout@v4
@@ -45,18 +48,30 @@ jobs:
           fi
           echo "should_deploy=true" >> "$GITHUB_OUTPUT"
 
+  deploy:
+    runs-on: ubuntu-latest
+    name: 🚀 Deploy to production
+    needs: sha-guard
+    if: needs.sha-guard.outputs.should_deploy == 'true'
+    environment:
+      name: production
+      url: ${{ steps.deploy.outputs.url }}
+    steps:
+      - name: 📦 Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
       - name: 🧰 Setup Bun
-        if: steps.sha_guard.outputs.should_deploy == 'true'
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
       - name: 📥 Install Dependencies
-        if: steps.sha_guard.outputs.should_deploy == 'true'
         run: bun install --frozen-lockfile
 
       - name: 🔐 Sync Cloudflare Secrets (bulk)
-        if: steps.sha_guard.outputs.should_deploy == 'true'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           COOKIE_SECRET: ${{ secrets.COOKIE_SECRET }}
@@ -70,13 +85,25 @@ jobs:
           RESEND_FROM_EMAIL
 
       - name: 🗄️ Apply D1 Migrations
-        if: steps.sha_guard.outputs.should_deploy == 'true'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: bun ./wrangler-env.ts d1 migrations apply epicflare --remote
 
       - name: ☁️ Deploy to Cloudflare Workers
-        if: steps.sha_guard.outputs.should_deploy == 'true'
+        id: deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        run: bun run deploy
+          APP_BASE_URL: ${{ secrets.APP_BASE_URL }}
+        run: |
+          set -euo pipefail
+
+          bun run deploy 2>&1 | tee deploy.log
+
+          DEPLOY_URL="${APP_BASE_URL:-}"
+          if [ -z "$DEPLOY_URL" ]; then
+            DEPLOY_URL="$(node -e "const fs = require('node:fs'); const t = fs.readFileSync('deploy.log','utf8'); const m = t.match(/https:\\/\\/[a-zA-Z0-9._-]+\\.workers\\.dev/g); process.stdout.write(m?.at(-1) ?? '')")"
+          fi
+
+          if [ -n "$DEPLOY_URL" ]; then
+            echo "url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
+          fi


### PR DESCRIPTION
Update production deploy workflow to use a GitHub environment, making it appear in Deployments.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-4ea28d24-47b4-4606-ace6-1535e940670e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4ea28d24-47b4-4606-ace6-1535e940670e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes that adjust job structure and metadata; primary risk is misconfigured gating/URL extraction causing deployments not to run or not to display correctly.
> 
> **Overview**
> Splits the production deploy workflow into a `sha-guard` job and a gated `deploy` job, so deploy steps only run when the validated SHA is still the current `main` HEAD.
> 
> Adds GitHub Deployments integration by granting `deployments: write`, attaching the `deploy` job to the `production` environment, and exporting a deployment URL (from `APP_BASE_URL` or parsed from deploy logs) to surface in the environment/deployments UI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d530c343dde5c2dbae55fc3c0aa80994fa3faeed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->