### PR TITLE
Mock service link tokens

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -186,7 +186,7 @@ jobs:
             echo "${service_key}_API_KEY=$MOCK_API_TOKEN" >> "$OVERRIDES_FILE"
 
             mock_summary="${mock_summary}\n- ${service}: ${mock_url} (\`${mock_worker_name}\`)"
-            mock_comment_summary="${mock_comment_summary}\n- ${service}: ${mock_url}/__mocks?token=${MOCK_API_TOKEN} (\`${mock_worker_name}\`)"
+            mock_comment_summary="${mock_comment_summary}\n- ${service}: [${mock_url}/__mocks](${mock_url}/__mocks?token=${MOCK_API_TOKEN}) (\`${mock_worker_name}\`)"
           done
 
           if [ -n "$mock_summary" ]; then

--- a/docs/agents/mock-api-servers.md
+++ b/docs/agents/mock-api-servers.md
@@ -25,5 +25,5 @@ it can also be deployed alongside the main app.
   `<app>-pr-<number>-mock-<service>` and configure the app preview to point at
   the deployed mock URL. A single generated token is shared between the app and
   all mock Workers for request authentication. The preview workflow includes an
-  authenticated dashboard link in the PR comment via `?token=...` so you can
-  open `/<service>/__mocks` without manually copying secrets.
+  authenticated dashboard link in the PR comment (href includes `?token=...`) so
+  you can open `/<service>/__mocks` without manually copying secrets.


### PR DESCRIPTION
Include the generated token query parameter in mock dashboard URLs shared in PR comments and update documentation to make mock services easier to use in PR previews.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-e72e873e-6e58-4a12-98dd-2aee25486c4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e72e873e-6e58-4a12-98dd-2aee25486c4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow/docs-only change; main impact is exposing the generated mock token in PR comments (still masked in logs), so risk is limited to preview ergonomics and token visibility.
> 
> **Overview**
> Updates the preview GitHub Actions workflow to generate a separate mock list for PR comments that links directly to each mock Worker’s `__mocks` dashboard with the generated `?token=...` query param, while keeping the step summary output unchanged.
> 
> Documentation is updated to note that PR preview comments now include these authenticated dashboard links to avoid manual token copying.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7caf824ab1f0a6b561becffc54c9e7a2a34b86f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->