### PR TITLE
Mock messages email body

### DIFF
--- a/mock-servers/resend/resend-mock.test.ts
+++ b/mock-servers/resend/resend-mock.test.ts
@@ -218,6 +218,8 @@ test(
 				from_email: string
 				to_json: string
 				subject: string
+				html: string
+				payload_json: string
 			}>
 		}
 		expect(listJson.count).toBe(1)
@@ -225,6 +227,10 @@ test(
 		expect(listJson.messages[0]?.from_email).toBe(email.from)
 		expect(JSON.parse(listJson.messages[0]?.to_json ?? 'null')).toEqual(
 			email.to,
+		)
+		expect(listJson.messages[0]?.html).toBe(email.html)
+		expect(JSON.parse(listJson.messages[0]?.payload_json ?? 'null')).toEqual(
+			email,
 		)
 	},
 	{ timeout: defaultTimeoutMs },

--- a/mock-servers/resend/worker.ts
+++ b/mock-servers/resend/worker.ts
@@ -177,7 +177,7 @@ async function listMessages(db: D1Database, tokenHash: string, limit: number) {
 	await ensureSchema(db)
 	const result = await db
 		.prepare(
-			`SELECT id, received_at, from_email, to_json, subject
+			`SELECT id, received_at, from_email, to_json, subject, html, payload_json
 			 FROM mock_resend_messages
 			 WHERE token_hash = ?
 			 ORDER BY received_at DESC
@@ -190,6 +190,8 @@ async function listMessages(db: D1Database, tokenHash: string, limit: number) {
 			from_email: string
 			to_json: string
 			subject: string
+			html: string
+			payload_json: string
 		}>()
 
 	return Array.isArray(result.results) ? result.results : []


### PR DESCRIPTION
Update Resend mock `GET /__mocks/messages` endpoint to return complete message data, including the email body.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-bba99342-5063-423c-a2e5-bc935c648fc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bba99342-5063-423c-a2e5-bc935c648fc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive change to a mock server response shape plus corresponding test updates; limited blast radius outside consumers of the mock listing endpoint.
> 
> **Overview**
> The Resend mock `GET /__mocks/messages` response now returns full message details by including `html` and a serialized `payload_json` alongside existing metadata.
> 
> Tests are updated to assert the new fields are present and match the email sent through `POST /emails`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25b43e253f9bb3f3f267374882c05ebadce09106. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->