### PR TITLE
chore(ci): delete GitHub preview environment on PR cleanup

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -40,6 +40,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  environments: write
 
 concurrency:
   group: >-
@@ -551,3 +552,62 @@ jobs:
         run: |
           set -euo pipefail
           bun tools/ci/preview-resources.ts cleanup --worker-name "$APP_WORKER_NAME"
+
+      - name: 🏷️ Delete GitHub preview environment
+        if: always()
+        uses: actions/github-script@v8.0.0
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          INPUT_TARGET: ${{ inputs.target }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+        with:
+          script: |
+            const eventName = process.env.EVENT_NAME;
+            let envName;
+            if (eventName === "pull_request") {
+              const n = process.env.PR_NUMBER;
+              if (!n) {
+                core.info("No PR number on event; skipping GitHub environment delete.");
+                return;
+              }
+              envName = `preview-${n}`;
+            } else if (
+              eventName === "workflow_dispatch" &&
+              process.env.INPUT_TARGET === "pr"
+            ) {
+              const n = process.env.INPUT_PR_NUMBER;
+              if (!n) {
+                core.info(
+                  "Manual cleanup without pr_number; skipping GitHub environment delete.",
+                );
+                return;
+              }
+              envName = `preview-${n}`;
+            } else {
+              core.info(
+                "Skipping GitHub environment delete (branch-targeted cleanups use a different naming scheme).",
+              );
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            try {
+              await github.request(
+                "DELETE /repos/{owner}/{repo}/environments/{environment_name}",
+                {
+                  owner,
+                  repo,
+                  environment_name: envName,
+                },
+              );
+              core.notice(`Deleted GitHub environment: ${envName}`);
+            } catch (e) {
+              if (e.status === 404) {
+                core.info(
+                  `GitHub environment not found (already deleted): ${envName}`,
+                );
+              } else {
+                throw e;
+              }
+            }


### PR DESCRIPTION
Adds `environments: write` to the preview workflow and deletes the `preview-<pr>` GitHub Environment when PR previews are torn down (PR `closed` or manual cleanup with `target=pr`), using the same naming as the deploy job.

Parity with the same change in kody.

Branch-targeted manual cleanups still skip GitHub environment deletion because those deploys use `preview-${{ github.run_id }}` when no PR number is set.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds `environments: write` permission and new deletion logic in the preview cleanup job, which broadens GitHub token capabilities and affects environment lifecycle during CI cleanup.
> 
> **Overview**
> **Preview cleanup now also removes the associated GitHub Environment.** The `preview.yml` workflow grants `environments: write` and, during the `cleanup` job, calls the GitHub API to delete the `preview-<pr_number>` environment when a PR is closed or when running manual cleanup with `target=pr`.
> 
> The deletion step is idempotent (ignores 404s) and intentionally skips branch-targeted manual cleanups where the environment naming differs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daec97dd86b1b057ff5a8629a5dc500caf6d06c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->