### PR TITLE
fix(ci): remove invalid `environments` permission from preview workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -40,7 +40,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  environments: write
 
 concurrency:
   group: >-


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The push after merging #67 failed workflow validation because `.github/workflows/preview.yml` was invalid: the top-level `permissions` block included `environments: write`, which is not a supported key in GitHub Actions’ workflow permissions schema. GitHub reported: `(Line: 43, Col: 3): Unexpected value 'environments'`.

This is unrelated to Vitest itself; the same push re-validated all workflows, so the invalid `preview.yml` from #69 surfaced.

## Change

Remove the invalid `environments: write` line. The cleanup job already deletes GitHub environments via the REST API using `github-script`, which uses the default `GITHUB_TOKEN` permissions for that API call.

## Verification

- Local: workflow YAML is now structurally valid per GitHub’s schema (no invalid permission keys).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c43ee348-51ca-4869-aa1d-cb8cd29f9f88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c43ee348-51ca-4869-aa1d-cb8cd29f9f88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

