### PR TITLE
fix(ci): preview cleanup no longer fails on GitHub environment delete

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -561,6 +561,10 @@ jobs:
           INPUT_TARGET: ${{ inputs.target }}
           INPUT_PR_NUMBER: ${{ inputs.pr_number }}
         with:
+          # The default GITHUB_TOKEN cannot delete deployment environments (403).
+          # Optional: set repo secret PREVIEW_ENV_CLEANUP_TOKEN to a PAT with repo
+          # scope (classic) or Administration: write (fine-grained) for this repo.
+          github-token: ${{ secrets.PREVIEW_ENV_CLEANUP_TOKEN || github.token }}
           script: |
             const eventName = process.env.EVENT_NAME;
             let envName;
@@ -605,6 +609,14 @@ jobs:
               if (e.status === 404) {
                 core.info(
                   `GitHub environment not found (already deleted): ${envName}`,
+                );
+              } else if (e.status === 403) {
+                core.warning(
+                  [
+                    `Cannot delete GitHub environment "${envName}" with the current token (403).`,
+                    "The default workflow token is not allowed to delete environments.",
+                    "Add repository secret PREVIEW_ENV_CLEANUP_TOKEN (PAT: classic `repo`, or fine-grained with Administration read/write on this repository) to enable automatic removal.",
+                  ].join(" "),
                 );
               } else {
                 throw e;

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -614,8 +614,8 @@ jobs:
                 core.warning(
                   [
                     `Cannot delete GitHub environment "${envName}" with the current token (403).`,
-                    "The default workflow token is not allowed to delete environments.",
-                    "Add repository secret PREVIEW_ENV_CLEANUP_TOKEN (PAT: classic `repo`, or fine-grained with Administration read/write on this repository) to enable automatic removal.",
+                    "The current token may not have permission to delete environments.",
+                    "If you're using the default workflow token, add repository secret PREVIEW_ENV_CLEANUP_TOKEN (PAT: classic `repo`, or fine-grained with Administration read/write on this repository). If you're already using a PAT, ensure it has the required permissions.",
                   ].join(" "),
                 );
               } else {

--- a/docs/agents/setup.md
+++ b/docs/agents/setup.md
@@ -121,6 +121,16 @@ each PR preview is isolated:
 When a PR is closed, the cleanup job deletes the preview Worker(s) and these
 resources as well.
 
+The same cleanup job removes the matching GitHub deployment environment
+(`preview-<pr>`). GitHub’s default `GITHUB_TOKEN` cannot call the delete
+environment API (you would see HTTP 403). That step is non-fatal: the workflow
+still succeeds and Cloudflare resources are still removed. To delete the GitHub
+environment automatically, add an Actions secret named
+`PREVIEW_ENV_CLEANUP_TOKEN` whose value is a personal access token with
+permission to administer this repository (for example a classic PAT with the
+`repo` scope, or a fine-grained PAT with **Administration** read and write on
+this repo only).
+
 Cloudflare Workers supports version `preview_urls`, but those preview URLs are
 not currently available for Workers that use Durable Objects. The main app
 Worker binds `MCP_OBJECT`, so app previews continue to use per-PR Worker names.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

[Run 24308663446](https://github.com/epicweb-dev/epicflare/actions/runs/24308663446) failed on **Cleanup Preview Resources** with `HttpError: Resource not accessible by integration` at the **Delete GitHub preview environment** step.

## Root cause

- [#69](https://github.com/epicweb-dev/epicflare/pull/69) added a step that calls `DELETE /repos/{owner}/{repo}/environments/{environment_name}`.
- The default `GITHUB_TOKEN` is not allowed to delete deployment environments (GitHub returns **403** for this API).
- [#70](https://github.com/epicweb-dev/epicflare/pull/70) removed `environments: write` from workflow `permissions` because that key is invalid for workflow YAML validation — but that permission was never a real fix for this API limitation anyway.

So the failure is not transient; it will recur on every PR close until the step stops throwing on 403.

## Changes

- Treat **403** like **404** for this step: log a warning and continue so Cloudflare cleanup still completes and the job is green.
- Support optional repo secret **`PREVIEW_ENV_CLEANUP_TOKEN`** (PAT with repo admin for this repository) passed to `actions/github-script` as `github-token` when maintainers want automatic GitHub environment removal.
- Document the behavior and secret in `docs/agents/setup.md`.

## Verification

- `bun run lint` and `bun run typecheck` pass.
- `bun run validate` still fails on `prettier --check` for several pre-existing files in the workspace (unchanged by this PR); formatted only the touched docs file.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad5c7630-65bf-4538-9083-056db08d67ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad5c7630-65bf-4538-9083-056db08d67ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

