### PR TITLE
Use the Navigation API in the client router

### DIFF
--- a/client/client-router.test.ts
+++ b/client/client-router.test.ts
@@ -12,9 +12,29 @@ type TestWindow = Window &
 	}
 
 const originalWindow = globalThis.window
+const originalFetch = globalThis.fetch
+const originalHtmlFormElement = globalThis.HTMLFormElement
+const originalHtmlButtonElement = globalThis.HTMLButtonElement
+const originalHtmlInputElement = globalThis.HTMLInputElement
 
 afterEach(() => {
 	vi.resetModules()
+	globalThis.fetch = originalFetch
+	if (originalHtmlFormElement) {
+		globalThis.HTMLFormElement = originalHtmlFormElement
+	} else {
+		Reflect.deleteProperty(globalThis, 'HTMLFormElement')
+	}
+	if (originalHtmlButtonElement) {
+		globalThis.HTMLButtonElement = originalHtmlButtonElement
+	} else {
+		Reflect.deleteProperty(globalThis, 'HTMLButtonElement')
+	}
+	if (originalHtmlInputElement) {
+		globalThis.HTMLInputElement = originalHtmlInputElement
+	} else {
+		Reflect.deleteProperty(globalThis, 'HTMLInputElement')
+	}
 	if (originalWindow) {
 		globalThis.window = originalWindow
 		return
@@ -118,4 +138,173 @@ test('listenToRouterNavigation rerenders for intercepted Navigation API events',
 
 	expect(intercepted).toBe(true)
 	expect(listenerCalls).toEqual(['navigate'])
+})
+
+test('reload navigations are not intercepted', async () => {
+	const navigationEventTarget = new EventTarget()
+	const locationAssign = vi.fn()
+
+	globalThis.window = {
+		location: {
+			assign: locationAssign,
+			hash: '',
+			href: 'https://example.com/account',
+			origin: 'https://example.com',
+			pathname: '/account',
+			search: '',
+		},
+		navigation: {
+			addEventListener: navigationEventTarget.addEventListener.bind(
+				navigationEventTarget,
+			),
+			dispatchEvent: navigationEventTarget.dispatchEvent.bind(navigationEventTarget),
+			navigate: vi.fn(() => ({
+				committed: Promise.resolve(),
+				finished: Promise.resolve(),
+			})),
+		},
+	} as unknown as TestWindow
+
+	const { listenToRouterNavigation } = await loadClientRouter()
+	const handle = {
+		on(target: EventTarget, listeners: Record<string, () => void>) {
+			for (const [eventName, eventListener] of Object.entries(listeners)) {
+				target.addEventListener(eventName, () => {
+					eventListener()
+				})
+			}
+		},
+	} as unknown as Handle
+
+	let notified = false
+	listenToRouterNavigation(handle, () => {
+		notified = true
+	})
+
+	let intercepted = false
+	const event = Object.assign(new Event('navigate'), {
+		canIntercept: true,
+		destination: {
+			url: 'https://example.com/account',
+		},
+		downloadRequest: null,
+		formData: null,
+		hashChange: false,
+		intercept() {
+			intercepted = true
+		},
+		navigationType: 'reload' as const,
+		sourceElement: null,
+	})
+
+	;(globalThis.window as TestWindow).navigation!.dispatchEvent(event)
+
+	expect(intercepted).toBe(false)
+	expect(notified).toBe(false)
+	expect(locationAssign).not.toHaveBeenCalled()
+})
+
+test('cross-origin post redirects fall back to document navigation', async () => {
+	const navigationEventTarget = new EventTarget()
+	const locationAssign = vi.fn()
+	const fetchMock = vi.fn(async () => {
+		return {
+			redirected: true,
+			headers: new Headers(),
+			status: 302,
+			statusText: 'Found',
+			url: 'https://oauth.example.com/authorize',
+		}
+	})
+
+	globalThis.fetch = fetchMock as unknown as typeof fetch
+	class MockHtmlFormElement {}
+	class MockHtmlButtonElement {}
+	class MockHtmlInputElement {}
+	globalThis.HTMLFormElement =
+		MockHtmlFormElement as unknown as typeof HTMLFormElement
+	globalThis.HTMLButtonElement =
+		MockHtmlButtonElement as unknown as typeof HTMLButtonElement
+	globalThis.HTMLInputElement =
+		MockHtmlInputElement as unknown as typeof HTMLInputElement
+	globalThis.window = {
+		location: {
+			assign: locationAssign,
+			hash: '',
+			href: 'https://example.com/login',
+			origin: 'https://example.com',
+			pathname: '/login',
+			search: '',
+		},
+		navigation: {
+			addEventListener: navigationEventTarget.addEventListener.bind(
+				navigationEventTarget,
+			),
+			dispatchEvent: navigationEventTarget.dispatchEvent.bind(navigationEventTarget),
+			navigate: vi.fn(() => ({
+				committed: Promise.resolve(),
+				finished: Promise.resolve(),
+			})),
+		},
+	} as unknown as TestWindow
+
+	const { listenToRouterNavigation } = await loadClientRouter()
+	const handle = {
+		on(target: EventTarget, listeners: Record<string, () => void>) {
+			for (const [eventName, eventListener] of Object.entries(listeners)) {
+				target.addEventListener(eventName, () => {
+					eventListener()
+				})
+			}
+		},
+	} as unknown as Handle
+	listenToRouterNavigation(handle, () => {
+		return
+	})
+
+	const controllerRedirect = vi.fn()
+	let interceptedHandler:
+		| ((controller: { redirect(url: string): void }) => Promise<void>)
+		| null = null
+	const form = new MockHtmlFormElement() as unknown as HTMLFormElement
+	Object.assign(form, {
+		getAttribute(name: string) {
+			if (name === 'method') return 'post'
+			if (name === 'action') return '/oauth/start'
+			return null
+		},
+		hasAttribute() {
+			return false
+		},
+	})
+
+	const event = Object.assign(new Event('navigate'), {
+		canIntercept: true,
+		destination: {
+			url: 'https://example.com/oauth/start',
+		},
+		downloadRequest: null,
+		formData: new FormData(),
+		hashChange: false,
+		intercept(options?: {
+			precommitHandler?: (controller: { redirect(url: string): void }) => Promise<void>
+			handler?: () => void | Promise<void>
+		}) {
+			interceptedHandler = options?.precommitHandler ?? null
+		},
+		navigationType: 'push' as const,
+		sourceElement: form,
+	})
+
+	;(globalThis.window as TestWindow).navigation!.dispatchEvent(event)
+	expect(interceptedHandler).not.toBeNull()
+
+	await interceptedHandler!({
+		redirect: controllerRedirect,
+	})
+
+	expect(controllerRedirect).toHaveBeenCalledWith('https://example.com/login', {
+		history: 'replace',
+	})
+	expect(locationAssign).not.toHaveBeenCalled()
 })

--- a/client/client-router.test.ts
+++ b/client/client-router.test.ts
@@ -1,6 +1,16 @@
 import { afterEach, expect, test, vi } from 'vitest'
 import { type Handle } from 'remix/component'
 
+type TestWindow = Window &
+	typeof globalThis & {
+		navigation?: EventTarget & {
+			navigate?: (url: string) => {
+				committed: Promise<unknown>
+				finished: Promise<unknown>
+			}
+		}
+	}
+
 const originalWindow = globalThis.window
 
 afterEach(() => {
@@ -31,13 +41,14 @@ test('navigate uses the Navigation API when available', async () => {
 			assign: vi.fn(),
 			hash: '',
 			href: 'https://example.com/',
+			origin: 'https://example.com',
 			pathname: '/',
 			search: '',
 		},
 		navigation: {
 			navigate: navigationNavigate,
 		},
-	} as unknown as Window & typeof globalThis
+	} as unknown as TestWindow
 
 	const { navigate } = await loadClientRouter()
 	navigate('/login?redirectTo=%2Faccount#start')
@@ -55,6 +66,7 @@ test('listenToRouterNavigation rerenders for intercepted Navigation API events',
 			assign: vi.fn(),
 			hash: '',
 			href: 'https://example.com/',
+			origin: 'https://example.com',
 			pathname: '/',
 			search: '',
 		},
@@ -68,7 +80,7 @@ test('listenToRouterNavigation rerenders for intercepted Navigation API events',
 				finished: Promise.resolve(),
 			})),
 		},
-	} as unknown as Window & typeof globalThis
+	} as unknown as TestWindow
 
 	const { listenToRouterNavigation } = await loadClientRouter()
 	const handle = {
@@ -102,7 +114,7 @@ test('listenToRouterNavigation rerenders for intercepted Navigation API events',
 		sourceElement: null,
 	})
 
-	globalThis.window.navigation!.dispatchEvent(event)
+	;(globalThis.window as TestWindow).navigation!.dispatchEvent(event)
 
 	expect(intercepted).toBe(true)
 	expect(listenerCalls).toEqual(['navigate'])

--- a/client/client-router.test.ts
+++ b/client/client-router.test.ts
@@ -16,6 +16,7 @@ const originalFetch = globalThis.fetch
 const originalHtmlFormElement = globalThis.HTMLFormElement
 const originalHtmlButtonElement = globalThis.HTMLButtonElement
 const originalHtmlInputElement = globalThis.HTMLInputElement
+const originalDocument = globalThis.document
 
 afterEach(() => {
 	vi.resetModules()
@@ -35,6 +36,11 @@ afterEach(() => {
 	} else {
 		Reflect.deleteProperty(globalThis, 'HTMLInputElement')
 	}
+	if (originalDocument) {
+		globalThis.document = originalDocument
+	} else {
+		Reflect.deleteProperty(globalThis, 'document')
+	}
 	if (originalWindow) {
 		globalThis.window = originalWindow
 		return
@@ -44,6 +50,25 @@ afterEach(() => {
 
 async function loadClientRouter() {
 	return import('./client-router.tsx')
+}
+
+function installDocumentStub() {
+	const documentEventTarget = new EventTarget()
+	class MockHtmlFormElement {}
+	class MockHtmlButtonElement {}
+	class MockHtmlInputElement {}
+	globalThis.HTMLFormElement =
+		MockHtmlFormElement as unknown as typeof HTMLFormElement
+	globalThis.HTMLButtonElement =
+		MockHtmlButtonElement as unknown as typeof HTMLButtonElement
+	globalThis.HTMLInputElement =
+		MockHtmlInputElement as unknown as typeof HTMLInputElement
+	globalThis.document = {
+		addEventListener: documentEventTarget.addEventListener.bind(documentEventTarget),
+		removeEventListener:
+			documentEventTarget.removeEventListener.bind(documentEventTarget),
+		dispatchEvent: documentEventTarget.dispatchEvent.bind(documentEventTarget),
+	} as unknown as Document
 }
 
 test('navigate uses the Navigation API when available', async () => {
@@ -80,6 +105,7 @@ test('navigate uses the Navigation API when available', async () => {
 test('listenToRouterNavigation rerenders for intercepted Navigation API events', async () => {
 	const navigationEventTarget = new EventTarget()
 	const listenerCalls: Array<string> = []
+	installDocumentStub()
 
 	globalThis.window = {
 		location: {
@@ -143,6 +169,7 @@ test('listenToRouterNavigation rerenders for intercepted Navigation API events',
 test('reload navigations are not intercepted', async () => {
 	const navigationEventTarget = new EventTarget()
 	const locationAssign = vi.fn()
+	installDocumentStub()
 
 	globalThis.window = {
 		location: {
@@ -204,32 +231,13 @@ test('reload navigations are not intercepted', async () => {
 	expect(locationAssign).not.toHaveBeenCalled()
 })
 
-test('cross-origin post redirects fall back to document navigation', async () => {
+test('navigate-event data-router-skip forms are not intercepted', async () => {
 	const navigationEventTarget = new EventTarget()
-	const locationAssign = vi.fn()
-	const fetchMock = vi.fn(async () => {
-		return {
-			redirected: true,
-			headers: new Headers(),
-			status: 302,
-			statusText: 'Found',
-			url: 'https://oauth.example.com/authorize',
-		}
-	})
+	installDocumentStub()
 
-	globalThis.fetch = fetchMock as unknown as typeof fetch
-	class MockHtmlFormElement {}
-	class MockHtmlButtonElement {}
-	class MockHtmlInputElement {}
-	globalThis.HTMLFormElement =
-		MockHtmlFormElement as unknown as typeof HTMLFormElement
-	globalThis.HTMLButtonElement =
-		MockHtmlButtonElement as unknown as typeof HTMLButtonElement
-	globalThis.HTMLInputElement =
-		MockHtmlInputElement as unknown as typeof HTMLInputElement
 	globalThis.window = {
 		location: {
-			assign: locationAssign,
+			assign: vi.fn(),
 			hash: '',
 			href: 'https://example.com/login',
 			origin: 'https://example.com',
@@ -258,23 +266,22 @@ test('cross-origin post redirects fall back to document navigation', async () =>
 			}
 		},
 	} as unknown as Handle
+
+	let notified = false
 	listenToRouterNavigation(handle, () => {
-		return
+		notified = true
 	})
 
-	const controllerRedirect = vi.fn()
-	let interceptedHandler:
-		| ((controller: { redirect(url: string): void }) => Promise<void>)
-		| null = null
-	const form = new MockHtmlFormElement() as unknown as HTMLFormElement
+	let intercepted = false
+	const form = new (globalThis.HTMLFormElement as typeof HTMLFormElement)()
 	Object.assign(form, {
 		getAttribute(name: string) {
 			if (name === 'method') return 'post'
 			if (name === 'action') return '/oauth/start'
 			return null
 		},
-		hasAttribute() {
-			return false
+		hasAttribute(name: string) {
+			return name === 'data-router-skip'
 		},
 	})
 
@@ -286,25 +293,15 @@ test('cross-origin post redirects fall back to document navigation', async () =>
 		downloadRequest: null,
 		formData: new FormData(),
 		hashChange: false,
-		intercept(options?: {
-			precommitHandler?: (controller: { redirect(url: string): void }) => Promise<void>
-			handler?: () => void | Promise<void>
-		}) {
-			interceptedHandler = options?.precommitHandler ?? null
+		intercept() {
+			intercepted = true
 		},
 		navigationType: 'push' as const,
 		sourceElement: form,
 	})
 
 	;(globalThis.window as TestWindow).navigation!.dispatchEvent(event)
-	expect(interceptedHandler).not.toBeNull()
 
-	await interceptedHandler!({
-		redirect: controllerRedirect,
-	})
-
-	expect(controllerRedirect).toHaveBeenCalledWith('https://example.com/login', {
-		history: 'replace',
-	})
-	expect(locationAssign).not.toHaveBeenCalled()
+	expect(intercepted).toBe(false)
+	expect(notified).toBe(false)
 })

--- a/client/client-router.test.ts
+++ b/client/client-router.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, expect, test, vi } from 'vitest'
+import { type Handle } from 'remix/component'
+
+const originalWindow = globalThis.window
+
+afterEach(() => {
+	vi.resetModules()
+	if (originalWindow) {
+		globalThis.window = originalWindow
+		return
+	}
+	Reflect.deleteProperty(globalThis, 'window')
+})
+
+async function loadClientRouter() {
+	return import('./client-router.tsx')
+}
+
+test('navigate uses the Navigation API when available', async () => {
+	const historyPushState = vi.fn()
+	const navigationNavigate = vi.fn(() => ({
+		committed: Promise.resolve(),
+		finished: Promise.resolve(),
+	}))
+
+	globalThis.window = {
+		history: {
+			pushState: historyPushState,
+		},
+		location: {
+			assign: vi.fn(),
+			hash: '',
+			href: 'https://example.com/',
+			pathname: '/',
+			search: '',
+		},
+		navigation: {
+			navigate: navigationNavigate,
+		},
+	} as unknown as Window & typeof globalThis
+
+	const { navigate } = await loadClientRouter()
+	navigate('/login?redirectTo=%2Faccount#start')
+
+	expect(navigationNavigate).toHaveBeenCalledWith('/login?redirectTo=%2Faccount#start')
+	expect(historyPushState).not.toHaveBeenCalled()
+})
+
+test('listenToRouterNavigation rerenders for intercepted Navigation API events', async () => {
+	const navigationEventTarget = new EventTarget()
+	const listenerCalls: Array<string> = []
+
+	globalThis.window = {
+		location: {
+			assign: vi.fn(),
+			hash: '',
+			href: 'https://example.com/',
+			pathname: '/',
+			search: '',
+		},
+		navigation: {
+			addEventListener: navigationEventTarget.addEventListener.bind(
+				navigationEventTarget,
+			),
+			dispatchEvent: navigationEventTarget.dispatchEvent.bind(navigationEventTarget),
+			navigate: vi.fn(() => ({
+				committed: Promise.resolve(),
+				finished: Promise.resolve(),
+			})),
+		},
+	} as unknown as Window & typeof globalThis
+
+	const { listenToRouterNavigation } = await loadClientRouter()
+	const handle = {
+		on(target: EventTarget, listeners: Record<string, () => void>) {
+			for (const [eventName, eventListener] of Object.entries(listeners)) {
+				target.addEventListener(eventName, () => {
+					eventListener()
+				})
+			}
+		},
+	} as unknown as Handle
+
+	listenToRouterNavigation(handle, () => {
+		listenerCalls.push('navigate')
+	})
+
+	let intercepted = false
+	const event = Object.assign(new Event('navigate'), {
+		canIntercept: true,
+		destination: {
+			url: 'https://example.com/login',
+		},
+		downloadRequest: null,
+		formData: null,
+		hashChange: false,
+		intercept(options?: { handler?: () => void | Promise<void> }) {
+			intercepted = true
+			options?.handler?.()
+		},
+		navigationType: 'push' as const,
+		sourceElement: null,
+	})
+
+	globalThis.window.navigation!.dispatchEvent(event)
+
+	expect(intercepted).toBe(true)
+	expect(listenerCalls).toEqual(['navigate'])
+})

--- a/client/client-router.tsx
+++ b/client/client-router.tsx
@@ -19,11 +19,6 @@ type RouterNavigationNavigateResult = {
 	finished: Promise<unknown>
 }
 
-type RouterNavigationPrecommitController = {
-	addHandler(handler: () => void | Promise<void>): void
-	redirect(url: string, options?: RouterNavigationNavigateOptions): void
-}
-
 type RouterNavigateEvent = Event & {
 	canIntercept: boolean
 	destination: {
@@ -35,9 +30,6 @@ type RouterNavigateEvent = Event & {
 	intercept(options?: {
 		focusReset?: 'after-transition' | 'manual'
 		handler?: () => void | Promise<void>
-		precommitHandler?: (
-			controller: RouterNavigationPrecommitController,
-		) => void | Promise<void>
 		scroll?: 'after-transition' | 'manual'
 	}): void
 	navigationType: 'push' | 'replace' | 'reload' | 'traverse'
@@ -218,39 +210,6 @@ function resolveFormSubmitDetails(
 	}
 }
 
-function resolveNavigateEventFormSubmitDetails(event: RouterNavigateEvent) {
-	if (!event.formData) return null
-
-	const { form, submitter } = getFormForSourceElement(event.sourceElement)
-	if (!form) return null
-	if (form.hasAttribute('data-router-skip')) return null
-
-	const method = normalizeFormMethod(
-		submitter?.getAttribute('formmethod') ?? form.getAttribute('method'),
-	)
-	if (method !== 'post') return null
-
-	const target = normalizeTarget(
-		submitter?.getAttribute('formtarget') ?? form.getAttribute('target'),
-	)
-	if (target && target !== '_self') return null
-
-	const enctype = (
-		submitter?.getAttribute('formenctype') ??
-		form.getAttribute('enctype') ??
-		'application/x-www-form-urlencoded'
-	)
-		.trim()
-		.toLowerCase()
-
-	return {
-		action: new URL(event.destination.url, window.location.href),
-		method,
-		enctype,
-		formData: event.formData,
-	} satisfies FormSubmitDetails
-}
-
 function formDataToSearchParams(formData: FormData) {
 	const params = new URLSearchParams()
 	for (const [name, value] of formData.entries()) {
@@ -369,50 +328,13 @@ function shouldInterceptNavigationEvent(event: RouterNavigateEvent) {
 	return true
 }
 
-function getRedirectHistoryForDestination(destination: URL): RouterNavigationHistory {
-	if (
-		getPathWithSearchAndHashFromUrl(destination) ===
-		getCurrentPathWithSearchAndHash()
-	) {
-		return 'replace'
-	}
-	return 'push'
-}
-
 function handleNavigationEvent(event: RouterNavigateEvent) {
 	if (!shouldInterceptNavigationEvent(event)) return
 
-	const formDetails = resolveNavigateEventFormSubmitDetails(event)
-	if (formDetails) {
-		let externalRedirect: URL | null = null
-		event.intercept({
-			async precommitHandler(controller) {
-				try {
-					const destination = await submitPostFormThroughRouter(formDetails)
-					if (!isSameOriginUrl(destination)) {
-						externalRedirect = destination
-						controller.redirect(window.location.href, {
-							history: 'replace',
-						})
-						return
-					}
-
-					controller.redirect(destination.toString(), {
-						history: getRedirectHistoryForDestination(destination),
-					})
-				} catch (error) {
-					console.error('Router form submit failed', error)
-					throw error
-				}
-			},
-			handler() {
-				if (externalRedirect) {
-					window.location.assign(externalRedirect.toString())
-					return
-				}
-				notify()
-			},
-		})
+	const { form } = getFormForSourceElement(event.sourceElement)
+	if (form) {
+		// Keep form submissions on the submit-handler path until precommit
+		// handling is consistently supported across Navigation API browsers.
 		return
 	}
 
@@ -427,6 +349,8 @@ function ensureRouter() {
 	if (routerInitialized) return
 	routerInitialized = true
 
+	document.addEventListener('submit', handleDocumentSubmit)
+
 	const navigationApi = getNavigationApi()
 	if (navigationApi) {
 		navigationApi.addEventListener('navigate', handleNavigationEvent)
@@ -435,7 +359,6 @@ function ensureRouter() {
 
 	window.addEventListener('popstate', notify)
 	document.addEventListener('click', handleDocumentClick)
-	document.addEventListener('submit', handleDocumentSubmit)
 }
 
 export function listenToRouterNavigation(handle: Handle, listener: () => void) {

--- a/client/client-router.tsx
+++ b/client/client-router.tsx
@@ -75,6 +75,10 @@ function getNavigationApi() {
 	return (window as Window & { navigation?: RouterNavigation }).navigation ?? null
 }
 
+function isSameOriginUrl(url: URL) {
+	return url.origin === window.location.origin
+}
+
 function compileRoutePattern(pattern: string) {
 	const regexPattern = pattern
 		.replace(/:([^/]+)/g, '([^/]+)')
@@ -358,9 +362,10 @@ function shouldInterceptNavigationEvent(event: RouterNavigateEvent) {
 	if (!event.canIntercept) return false
 	if (event.downloadRequest !== null) return false
 	if (event.hashChange) return false
+	if (event.navigationType === 'reload') return false
 
 	const destination = new URL(event.destination.url, window.location.href)
-	if (destination.origin !== window.location.origin) return false
+	if (!isSameOriginUrl(destination)) return false
 	return true
 }
 
@@ -379,10 +384,19 @@ function handleNavigationEvent(event: RouterNavigateEvent) {
 
 	const formDetails = resolveNavigateEventFormSubmitDetails(event)
 	if (formDetails) {
+		let externalRedirect: URL | null = null
 		event.intercept({
 			async precommitHandler(controller) {
 				try {
 					const destination = await submitPostFormThroughRouter(formDetails)
+					if (!isSameOriginUrl(destination)) {
+						externalRedirect = destination
+						controller.redirect(window.location.href, {
+							history: 'replace',
+						})
+						return
+					}
+
 					controller.redirect(destination.toString(), {
 						history: getRedirectHistoryForDestination(destination),
 					})
@@ -392,6 +406,10 @@ function handleNavigationEvent(event: RouterNavigateEvent) {
 				}
 			},
 			handler() {
+				if (externalRedirect) {
+					window.location.assign(externalRedirect.toString())
+					return
+				}
 				notify()
 			},
 		})

--- a/client/client-router.tsx
+++ b/client/client-router.tsx
@@ -7,6 +7,55 @@ type RouterSetup = {
 
 type FormMethod = 'get' | 'post'
 
+type RouterNavigationHistory = 'push' | 'replace'
+
+type RouterNavigationNavigateOptions = {
+	history?: 'auto' | RouterNavigationHistory
+	state?: unknown
+}
+
+type RouterNavigationNavigateResult = {
+	committed: Promise<unknown>
+	finished: Promise<unknown>
+}
+
+type RouterNavigationPrecommitController = {
+	addHandler(handler: () => void | Promise<void>): void
+	redirect(url: string, options?: RouterNavigationNavigateOptions): void
+}
+
+type RouterNavigateEvent = Event & {
+	canIntercept: boolean
+	destination: {
+		url: string
+	}
+	downloadRequest: string | null
+	formData: FormData | null
+	hashChange: boolean
+	intercept(options?: {
+		focusReset?: 'after-transition' | 'manual'
+		handler?: () => void | Promise<void>
+		precommitHandler?: (
+			controller: RouterNavigationPrecommitController,
+		) => void | Promise<void>
+		scroll?: 'after-transition' | 'manual'
+	}): void
+	navigationType: 'push' | 'replace' | 'reload' | 'traverse'
+	sourceElement: Element | null
+}
+
+type RouterNavigation = EventTarget & {
+	addEventListener(
+		type: 'navigate',
+		listener: (event: RouterNavigateEvent) => void,
+		options?: AddEventListenerOptions | boolean,
+	): void
+	navigate(
+		url: string,
+		options?: RouterNavigationNavigateOptions,
+	): RouterNavigationNavigateResult
+}
+
 type FormSubmitDetails = {
 	action: URL
 	method: FormMethod
@@ -19,6 +68,11 @@ let routerInitialized = false
 
 function notify() {
 	routerEvents.dispatchEvent(new Event('navigate'))
+}
+
+function getNavigationApi() {
+	if (typeof window === 'undefined') return null
+	return (window as Window & { navigation?: RouterNavigation }).navigation ?? null
 }
 
 function compileRoutePattern(pattern: string) {
@@ -93,6 +147,28 @@ function normalizeTarget(rawTarget: string | null) {
 	return (rawTarget ?? '').trim().toLowerCase()
 }
 
+function getFormForSourceElement(sourceElement: Element | null) {
+	if (sourceElement instanceof HTMLFormElement) {
+		return {
+			form: sourceElement,
+			submitter: null,
+		}
+	}
+	if (
+		sourceElement instanceof HTMLButtonElement ||
+		sourceElement instanceof HTMLInputElement
+	) {
+		return {
+			form: sourceElement.form,
+			submitter: sourceElement,
+		}
+	}
+	return {
+		form: null,
+		submitter: null,
+	}
+}
+
 function createSubmitFormData(
 	form: HTMLFormElement,
 	submitter: HTMLButtonElement | HTMLInputElement | null,
@@ -138,6 +214,39 @@ function resolveFormSubmitDetails(
 	}
 }
 
+function resolveNavigateEventFormSubmitDetails(event: RouterNavigateEvent) {
+	if (!event.formData) return null
+
+	const { form, submitter } = getFormForSourceElement(event.sourceElement)
+	if (!form) return null
+	if (form.hasAttribute('data-router-skip')) return null
+
+	const method = normalizeFormMethod(
+		submitter?.getAttribute('formmethod') ?? form.getAttribute('method'),
+	)
+	if (method !== 'post') return null
+
+	const target = normalizeTarget(
+		submitter?.getAttribute('formtarget') ?? form.getAttribute('target'),
+	)
+	if (target && target !== '_self') return null
+
+	const enctype = (
+		submitter?.getAttribute('formenctype') ??
+		form.getAttribute('enctype') ??
+		'application/x-www-form-urlencoded'
+	)
+		.trim()
+		.toLowerCase()
+
+	return {
+		action: new URL(event.destination.url, window.location.href),
+		method,
+		enctype,
+		formData: event.formData,
+	} satisfies FormSubmitDetails
+}
+
 function formDataToSearchParams(formData: FormData) {
 	const params = new URLSearchParams()
 	for (const [name, value] of formData.entries()) {
@@ -181,12 +290,7 @@ function navigateWithRefreshForSamePath(destination: URL) {
 	navigate(destination.toString())
 }
 
-async function submitFormThroughRouter(details: FormSubmitDetails) {
-	if (details.method === 'get') {
-		navigate(buildGetDestination(details.action, details.formData).toString())
-		return
-	}
-
+async function submitPostFormThroughRouter(details: FormSubmitDetails) {
 	const init: RequestInit = {
 		method: details.method.toUpperCase(),
 		credentials: 'include',
@@ -209,19 +313,27 @@ async function submitFormThroughRouter(details: FormSubmitDetails) {
 
 	const response = await fetch(details.action.toString(), init)
 	if (response.redirected) {
-		navigateWithRefreshForSamePath(new URL(response.url, window.location.href))
-		return
+		return new URL(response.url, window.location.href)
 	}
 
 	const location = response.headers.get('Location')
 	if (location) {
-		navigateWithRefreshForSamePath(new URL(location, details.action))
-		return
+		return new URL(location, details.action)
 	}
 
 	throw new Error(
 		`Expected redirect location after form submit (${response.status} ${response.statusText})`,
 	)
+}
+
+async function submitFormThroughRouter(details: FormSubmitDetails) {
+	if (details.method === 'get') {
+		navigate(buildGetDestination(details.action, details.formData).toString())
+		return
+	}
+
+	const destination = await submitPostFormThroughRouter(details)
+	navigateWithRefreshForSamePath(destination)
 }
 
 function handleDocumentSubmit(event: Event) {
@@ -241,9 +353,68 @@ function handleDocumentSubmit(event: Event) {
 	})
 }
 
+function shouldInterceptNavigationEvent(event: RouterNavigateEvent) {
+	if (typeof window === 'undefined') return false
+	if (!event.canIntercept) return false
+	if (event.downloadRequest !== null) return false
+	if (event.hashChange) return false
+
+	const destination = new URL(event.destination.url, window.location.href)
+	if (destination.origin !== window.location.origin) return false
+	return true
+}
+
+function getRedirectHistoryForDestination(destination: URL): RouterNavigationHistory {
+	if (
+		getPathWithSearchAndHashFromUrl(destination) ===
+		getCurrentPathWithSearchAndHash()
+	) {
+		return 'replace'
+	}
+	return 'push'
+}
+
+function handleNavigationEvent(event: RouterNavigateEvent) {
+	if (!shouldInterceptNavigationEvent(event)) return
+
+	const formDetails = resolveNavigateEventFormSubmitDetails(event)
+	if (formDetails) {
+		event.intercept({
+			async precommitHandler(controller) {
+				try {
+					const destination = await submitPostFormThroughRouter(formDetails)
+					controller.redirect(destination.toString(), {
+						history: getRedirectHistoryForDestination(destination),
+					})
+					controller.addHandler(() => {
+						notify()
+					})
+				} catch (error) {
+					console.error('Router form submit failed', error)
+					throw error
+				}
+			},
+		})
+		return
+	}
+
+	event.intercept({
+		handler() {
+			notify()
+		},
+	})
+}
+
 function ensureRouter() {
 	if (routerInitialized) return
 	routerInitialized = true
+
+	const navigationApi = getNavigationApi()
+	if (navigationApi) {
+		navigationApi.addEventListener('navigate', handleNavigationEvent)
+		return
+	}
+
 	window.addEventListener('popstate', notify)
 	document.addEventListener('click', handleDocumentClick)
 	document.addEventListener('submit', handleDocumentSubmit)
@@ -276,6 +447,12 @@ export function navigate(to: string) {
 
 	const nextPath = `${destination.pathname}${destination.search}${destination.hash}`
 	if (nextPath === getCurrentPathWithSearchAndHash()) return
+
+	const navigationApi = getNavigationApi()
+	if (navigationApi) {
+		navigationApi.navigate(nextPath)
+		return
+	}
 
 	window.history.pushState({}, '', nextPath)
 	notify()

--- a/client/client-router.tsx
+++ b/client/client-router.tsx
@@ -386,13 +386,13 @@ function handleNavigationEvent(event: RouterNavigateEvent) {
 					controller.redirect(destination.toString(), {
 						history: getRedirectHistoryForDestination(destination),
 					})
-					controller.addHandler(() => {
-						notify()
-					})
 				} catch (error) {
 					console.error('Router form submit failed', error)
 					throw error
 				}
+			},
+			handler() {
+				notify()
 			},
 		})
 		return


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- switch the client router to prefer the web standard Navigation API for same-document routing
- keep form submissions on the explicit submit-handler path so skipped forms and browsers without `precommitHandler` support still submit correctly
- preserve reload behavior by skipping Navigation API interception for browser reloads and add focused router tests for the review-reported edge cases

## Testing
- `bunx vitest run client/client-router.test.ts client/app-session-refresh.test.ts`
- `bun run typecheck`
- `bunx oxlint client/client-router.tsx client/client-router.test.ts`
- `PLAYWRIGHT_PORT=8802 bun run test:e2e e2e/home.spec.ts e2e/account.spec.ts`

## Walkthrough
<a href="https://cursor.com/agents/bc-f683a385-f944-437b-a3b1-003fe52adc10/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnavigation-api-router-demo.mp4"><img src="https://cursor.com/artifacts/c/art-2eaef926-3473-4e48-bd55-89c9a4d0c9c0" alt="navigation-api-router-demo.mp4" /></a>
![Navigation API login link marker persistence](https://cursor.com/artifacts/c/art-99b1a6dd-cdb8-4e37-9c8a-65a4f03814b3)
![Navigation API logout marker persistence](https://cursor.com/artifacts/c/art-1f07270a-b467-4fe1-a27f-032cac1a415c)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f683a385-f944-437b-a3b1-003fe52adc10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f683a385-f944-437b-a3b1-003fe52adc10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

