### PR TITLE
Upgrade Remix to 3.0.0 beta 4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "@modelcontextprotocol/sdk": "1.26.0",
         "agents": "^0.7.6",
         "get-port": "^7.1.0",
-        "remix": "3.0.0-beta.0",
+        "remix": "3.0.0-beta.4",
         "workers-ai-provider": "^3.1.2",
         "zod": "^4.3.6",
       },
@@ -471,91 +471,93 @@
 
     "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
 
-    "@remix-run/assert": ["@remix-run/assert@0.2.0", "", {}, "sha512-SNfcxPQstoIBr/hbRSsTYLNnmIXMgiL4cY8o5HH9PE7Ue/NQcIwqNJtvV0xVrk3pY/ywxHhAwSl2V8ao1Is9Cg=="],
+    "@remix-run/assert": ["@remix-run/assert@0.3.0", "", {}, "sha512-GBA9klvJdG5YSTwRNur54LQcfqDOtir+x1TDbv3dzB9FS2Li9CEiRLp1EpBcaYrj4ByO03WJCWFBiY8bTMy4vQ=="],
 
-    "@remix-run/assets": ["@remix-run/assets@0.3.0", "", { "dependencies": { "@oxc-project/runtime": "^0.121.0", "@remix-run/headers": "0.19.0", "@remix-run/route-pattern": "0.20.1", "chokidar": "^5.0.0", "es-module-lexer": "^2.0.0", "get-tsconfig": "^4.13.6", "lightningcss": "^1.32.0", "magic-string": "^0.30.21", "oxc-minify": "^0.121.0", "oxc-parser": "^0.121.0", "oxc-resolver": "^11.19.1", "oxc-transform": "^0.121.0", "picomatch": "^4.0.4", "source-map-js": "^1.2.1" } }, "sha512-WmnAgg+D4BA70r4VccW3LF/XPl192NY+7+SicBCeMLu6KKH7lNW5cFqL9e0GM2bmyL9lP8EVNEd/Ld/c9kCxyg=="],
+    "@remix-run/assets": ["@remix-run/assets@0.4.3", "", { "dependencies": { "@oxc-project/runtime": "^0.121.0", "@remix-run/file-storage": "0.13.6", "@remix-run/headers": "0.21.1", "@remix-run/mime": "0.4.1", "@remix-run/route-pattern": "0.22.1", "chokidar": "^5.0.0", "es-module-lexer": "^2.0.0", "get-tsconfig": "^4.13.6", "lightningcss": "^1.32.0", "magic-string": "^0.30.21", "oxc-minify": "^0.121.0", "oxc-parser": "^0.121.0", "oxc-resolver": "^11.19.1", "oxc-transform": "^0.121.0", "picomatch": "^4.0.4", "source-map-js": "^1.2.1" } }, "sha512-3YKANQIc/dATxy9+7VpaILXZ4KPOP7y888EbyAphvEu++jOILpjHxMi5N+fhXoRZxpmL+CXaB7PKEwbsAAnKpA=="],
 
-    "@remix-run/async-context-middleware": ["@remix-run/async-context-middleware@0.2.2", "", { "dependencies": { "@remix-run/fetch-router": "^0.18.2" } }, "sha512-zDuA5HoSAEqaPkjJFg8sSYeYxZK1s6kWUSXlOzcOxgQC9DHk5X3f1pl552zbq/MSzQo1MgzTBgFxQ5Lu8UTLAQ=="],
+    "@remix-run/async-context-middleware": ["@remix-run/async-context-middleware@0.3.3", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.0" } }, "sha512-Qg53vPttFVX9kxYjn8dxd+/BpCCe9gaYGPUze+YAMvQ73InKyeTF1a4zqnmHgHxTVp2qYK+kp0derTVlRAMTpQ=="],
 
-    "@remix-run/auth": ["@remix-run/auth@0.2.1", "", { "dependencies": { "@remix-run/fetch-router": "^0.18.2", "@remix-run/session": "^0.4.1" } }, "sha512-KGX1y1h7eZiCVU204Z9NZhOjV+zhF4wktm5gOuiUoVN95oYTh9BFEEIsyGQdxHhxTH31hWUNNh2Aj5dCrr/u6Q=="],
+    "@remix-run/auth": ["@remix-run/auth@0.2.5", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.0", "@remix-run/session": "^0.4.2" } }, "sha512-liwLro3rHgtjTc3MuYD4iKlZUcVvAzZUSGk0Tc1JFd7QSI8E8G2QeCxJvZRpul6TO0ojnjSogNydmj42ZpI4iQ=="],
 
-    "@remix-run/auth-middleware": ["@remix-run/auth-middleware@0.1.2", "", { "dependencies": { "@remix-run/fetch-router": "^0.18.2", "@remix-run/session": "^0.4.1" } }, "sha512-hXv0tCKNcwcSWAKYTTxtaKM+xiWk/U4ZL4IKlk5pHLiEaFoYykSgVOlMB59cmZuovqt74ju7YQME9MW2zhnFEA=="],
+    "@remix-run/auth-middleware": ["@remix-run/auth-middleware@0.2.3", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.0", "@remix-run/session": "^0.4.2" } }, "sha512-dUt/b/Vj4dntpORbQ9bV51eWyi7DyHM7zV4EfbSGsw7jyYfwtRptqu5Y3gAW6YlGAM1jp+ahSUMSzOqb1EEKWw=="],
 
-    "@remix-run/cli": ["@remix-run/cli@0.2.0", "", { "dependencies": { "@remix-run/terminal": "^0.1.0", "@remix-run/test": "^0.3.0", "semver": "^7.7.4" } }, "sha512-u0xOE0GUF98OSfonAtVOFLRC4rPM9mmenXkVfwHu3VZHENRpkafmi/zkdkvwDdJMp2/ucODlFd5gmfC0/CCiMA=="],
+    "@remix-run/cli": ["@remix-run/cli@0.3.3", "", { "dependencies": { "@remix-run/terminal": "^0.1.1", "@remix-run/test": "^0.5.0", "semver": "^7.7.4" } }, "sha512-3ho5CuzpIA6IIyY48EvAsA5I2c5mlT6RNvGa5/oSi6OutgNX+Fb9UDLIw7MbvKRvaIL6b/XOHT0LCQ+TrIAL+g=="],
 
-    "@remix-run/compression-middleware": ["@remix-run/compression-middleware@0.1.7", "", { "dependencies": { "@remix-run/fetch-router": "^0.18.2", "@remix-run/mime": "^0.4.1", "@remix-run/response": "^0.3.3" } }, "sha512-7sdpcNYHSuA2X4lkpzCclOTsQY1WQ2JHwahAF7Pcsx1lF8FKniSjgdjubMsl/mOrbK1ajeefIkBDA4wpF3E8Gw=="],
+    "@remix-run/compression-middleware": ["@remix-run/compression-middleware@0.1.11", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.0", "@remix-run/mime": "^0.4.1", "@remix-run/response": "^0.3.6" } }, "sha512-VgnCV8cZqH11HhBXqIbgskUaK7ORkFlVBy9I+6dQQKWpDv/WnouFtKI2anlAfYqUZ+6WCfyBTNlq5FfbAz5lVA=="],
 
-    "@remix-run/cookie": ["@remix-run/cookie@0.5.1", "", { "dependencies": { "@remix-run/headers": "^0.19.0" } }, "sha512-gbeZfVd1AKRlFj3IJWcIcR6zqVGz2XGJhR+mcqYiWnYt6KM8oUGtc82dsc4qZnWWA1f0nM4/He9wrU4GjB0pag=="],
+    "@remix-run/cookie": ["@remix-run/cookie@0.5.4", "", { "dependencies": { "@remix-run/headers": "^0.21.1" } }, "sha512-QxV2yo0umBXxwMub8kZFC+nOFnGMVpGo3jQ1Gvs4p1n2N7/0LAKhPgKsWbsk5ab6EqVhpr0S+v9gSQON1nuyoA=="],
 
-    "@remix-run/cop-middleware": ["@remix-run/cop-middleware@0.1.2", "", { "dependencies": { "@remix-run/fetch-router": "^0.18.2" } }, "sha512-8N0yGKuEeP9AD+1uyq/kwF+F82gmG2otGt4nzzXOYDm/6D7pkFfAvQpV2Fhv6sNYtntKQnIzyTMa6tdMXP3n0A=="],
+    "@remix-run/cop-middleware": ["@remix-run/cop-middleware@0.1.6", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.0" } }, "sha512-KPTHCIunLQxzNHXPel0jYFpKcmM7TF9GxMaitV0NGh8JktRDX0ckS+6lpHk7gGf06lIBYcafgqwrIVdp/LXSXg=="],
 
-    "@remix-run/cors-middleware": ["@remix-run/cors-middleware@0.1.2", "", { "dependencies": { "@remix-run/fetch-router": "^0.18.2", "@remix-run/headers": "^0.19.0" } }, "sha512-+tyo+npF+6szzVorrApp0Ilx+UZUdHlSTu5HJG/Nh1zw/gavWEeMtBw9ZWEWz8EhZZ03vVYnTvlEUW5GRhW3TA=="],
+    "@remix-run/cors-middleware": ["@remix-run/cors-middleware@0.1.6", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.0", "@remix-run/headers": "^0.21.1" } }, "sha512-n4+sL7ePUhtWKrTjSfjs37sgz228cZPQbSyOEPy6b8nGhX8cRDFYqkF3M9BSelxoP4sWfIQZTaE1LTGAemHrrA=="],
 
-    "@remix-run/csrf-middleware": ["@remix-run/csrf-middleware@0.1.2", "", { "dependencies": { "@remix-run/fetch-router": "^0.18.2", "@remix-run/session": "^0.4.1" } }, "sha512-f+l8f3sBD3xBec2kKKvEVwPLLD7No96Xf8nOYXhuPyeSy2iRaeRG+psqpZ0nH4WukU0/mmWXxuM0/DkPxr4mgg=="],
+    "@remix-run/csrf-middleware": ["@remix-run/csrf-middleware@0.1.6", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.0", "@remix-run/session": "^0.4.2" } }, "sha512-qqF92bQFwKu3qnLvMjFPhf6B0gHr4U4ZolLFcfOVgK8OcszHZQdBCLwmwGu+G6MxbaNnk0OtE+kL36liJ5+Tzw=="],
 
     "@remix-run/data-schema": ["@remix-run/data-schema@0.3.0", "", { "dependencies": { "@standard-schema/spec": "^1.1.0" } }, "sha512-rjGaFJduzO3iMFOKwA5URpZDuGbUxgBwcX9myBglfqbax8dBlhRcxurydepq+xi+XBE+bPrT9V57Jur6p1igow=="],
 
-    "@remix-run/data-table": ["@remix-run/data-table@0.2.1", "", {}, "sha512-p7LFOzgSmRws6U7N2karl+t85J/8jKtUjtKb3XxvCBWEwJk2XZ2nVhhhmamdN5+XEzgFK/KGnNyRtdu114v7sA=="],
+    "@remix-run/data-table": ["@remix-run/data-table@0.3.0", "", {}, "sha512-2Ikjlm3T2qtMTeWm5v/76iXEP2fqqdJGxjTZ6OFre5b5BFoRyaq/iBmDc0lkXPoOGvkeOxNuRo7L0dRkMTXwJQ=="],
 
-    "@remix-run/data-table-mysql": ["@remix-run/data-table-mysql@0.3.1", "", { "dependencies": { "@remix-run/data-table": "^0.2.1" }, "peerDependencies": { "mysql2": "^3.15.3" }, "optionalPeers": ["mysql2"] }, "sha512-AG02+HbMlBsxuX9/3Y285YO1/ZPCWcQV6+eVthDZ0ub0ksZ7xNqY54LW6XF9b2QM++8yRTMKPTIElhJgyb6UgQ=="],
+    "@remix-run/data-table-mysql": ["@remix-run/data-table-mysql@0.4.0", "", { "dependencies": { "@remix-run/data-table": "^0.3.0" }, "peerDependencies": { "mysql2": "^3.15.3" }, "optionalPeers": ["mysql2"] }, "sha512-1HUCmQ7mj0tbkzku8X4z7Y7TaaYMf45Eyh5iqnKB4qT9Jb44XEOjAVveALZ1QchIb0T/72cZ2Gx9YXY7okad+A=="],
 
-    "@remix-run/data-table-postgres": ["@remix-run/data-table-postgres@0.3.1", "", { "dependencies": { "@remix-run/data-table": "^0.2.1" }, "peerDependencies": { "pg": "^8.16.3" }, "optionalPeers": ["pg"] }, "sha512-wveXpsPwesuWtNPWrRrWq5XL4y1Jkk6uBfIYCd9twPyDOX5urCjwZzI8muPW+X1Gs3co5NWZK8+TjI0t+uYW6w=="],
+    "@remix-run/data-table-postgres": ["@remix-run/data-table-postgres@0.4.0", "", { "dependencies": { "@remix-run/data-table": "^0.3.0" }, "peerDependencies": { "pg": "^8.16.3" }, "optionalPeers": ["pg"] }, "sha512-aOcAYhdgJ99J+BUNrgBrD/RapQt43UbzkGUihm5zhK8S0G5I/gd+TBAw1t8vuutvSw0Zjg1cfDCBihkjMJ4uGQ=="],
 
-    "@remix-run/data-table-sqlite": ["@remix-run/data-table-sqlite@0.4.1", "", { "dependencies": { "@remix-run/data-table": "^0.2.1" } }, "sha512-l4ZtPaviYKF/hiDXBbb35lnbye9m+X31B1RcPNUA6DNF0u5jwAFbaUfVRB+CwfJgv+PNZx9FXJbmMW5vK1Giwg=="],
+    "@remix-run/data-table-sqlite": ["@remix-run/data-table-sqlite@0.5.1", "", { "dependencies": { "@remix-run/data-table": "^0.3.0" } }, "sha512-YgpUz49eeddYHOY3ebWi4Xeu94KWICRPrmsotkWpTIQdnf/sV+Ddx8BS4kUs+y9JJ/efrjAeHl/LNH6swpvM8g=="],
 
-    "@remix-run/fetch-proxy": ["@remix-run/fetch-proxy@0.8.0", "", { "dependencies": { "@remix-run/headers": "^0.19.0" } }, "sha512-kUBHz1ykwpS9eiWWeakdsvyIRyNSxKqFJCX2dwceUMOFuGtHkdN96gF1fyv9f6oxhRZCApgm4sjrdL67VpOfhA=="],
+    "@remix-run/fetch-proxy": ["@remix-run/fetch-proxy@0.8.3", "", { "dependencies": { "@remix-run/headers": "^0.21.1" } }, "sha512-FP2/0DIdnPGXMk+UAsRhYmunj3ElH2QNjuvD7VjjyWOAs9vHn7XnvfKk+qs1VDXAO5J9fkzwPQ+Y0n9FJZ8srQ=="],
 
-    "@remix-run/fetch-router": ["@remix-run/fetch-router@0.18.2", "", { "dependencies": { "@remix-run/route-pattern": "^0.20.1" } }, "sha512-/yZkz81ZwzWcZR9od+PIOfwavsreC62TmRdSYESznThYYhVezLkvvRLvNh0v8hAaSOIzNkoLN/wc037m67mm4Q=="],
+    "@remix-run/fetch-router": ["@remix-run/fetch-router@0.20.0", "", { "dependencies": { "@remix-run/route-pattern": "^0.22.1" } }, "sha512-iNjDAesu37Yf8nApAkKgKjmZBavC+AuzWK9EUmiwo+OnH7nn8ag5whyVFR4kb0LJN5CeXciFEIjX+oHG5cNeyw=="],
 
-    "@remix-run/file-storage": ["@remix-run/file-storage@0.13.4", "", { "dependencies": { "@remix-run/fs": "^0.4.3", "@remix-run/lazy-file": "^5.0.3" } }, "sha512-DunIIfs5/qpxQRvlxs5OT1I8TMiZqf7zbCOzKz6LJconD5lC97P58UKOfwS69hfxhg3NyBGFqhBuQ+QhYUCAOQ=="],
+    "@remix-run/file-storage": ["@remix-run/file-storage@0.13.6", "", { "dependencies": { "@remix-run/fs": "^0.4.5", "@remix-run/lazy-file": "^5.0.5" } }, "sha512-dXX7gcoPPWFa/041U/fCW9jHS11v8oC8UCrMRpbkyltz+tI55KvJ60oHYPUqnu75b9Ep60lZHvNviqlSn1Iv4w=="],
 
-    "@remix-run/file-storage-s3": ["@remix-run/file-storage-s3@0.1.1", "", { "dependencies": { "@remix-run/file-storage": "^0.13.4", "aws4fetch": "^1.0.20" } }, "sha512-ylE9w6A6mrX4OystdNbIRNqozADgnnnEly9m53VDb3yO+CDYc+izFQZ93R3uPqC7jUenuG4Jc07Yv709J8Z/SA=="],
+    "@remix-run/file-storage-s3": ["@remix-run/file-storage-s3@0.1.3", "", { "dependencies": { "@remix-run/file-storage": "^0.13.6", "aws4fetch": "^1.0.20" } }, "sha512-15OlGiiiSJnM4KlrcCxYBqIRHAubNEy8LsBRnI/bXXzsSgNOS/gnAi9dhjkgHScLPtgr8Xf0kyO1zUl82/41dA=="],
 
-    "@remix-run/form-data-middleware": ["@remix-run/form-data-middleware@0.2.3", "", { "dependencies": { "@remix-run/fetch-router": "^0.18.2", "@remix-run/form-data-parser": "^0.17.0" } }, "sha512-gaHAQay7ckLcmkpJpPJlYgN5vJpXp+WLdHUCC8MiAJ0uFWhyaKDzKZvjewq7V0InVwi/M0J0Fvyaa2ljocq+3w=="],
+    "@remix-run/form-data-middleware": ["@remix-run/form-data-middleware@0.3.3", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.0", "@remix-run/form-data-parser": "^0.17.3" } }, "sha512-46FpwGGyjJXvH1ZioZtL8FGO14qDASqaZmnqXmeUspZ4XvtEVAiEfzcPYUnmCNzrvBSuGlgU5WqUfOQxbtXAHA=="],
 
-    "@remix-run/form-data-parser": ["@remix-run/form-data-parser@0.17.0", "", { "dependencies": { "@remix-run/multipart-parser": "^0.16.0" } }, "sha512-012VyeBYzqHxg/c6n882qDdHgR/hLk+bT+Eh9nb2CCfzt5OtkhAIuQOCj1Me9KZs3x23Rfe06ybZZ8k/dp3cxw=="],
+    "@remix-run/form-data-parser": ["@remix-run/form-data-parser@0.17.3", "", { "dependencies": { "@remix-run/multipart-parser": "^0.16.3" } }, "sha512-K23ImS2P+Gl4ZEK00dEa2GAuhQJkxocvMsnF5SafcRh4aoKINUcdiCQraBDP+929c3VxnP3nUj5UYzBtGuGIIw=="],
 
-    "@remix-run/fs": ["@remix-run/fs@0.4.3", "", { "dependencies": { "@remix-run/lazy-file": "^5.0.3", "@remix-run/mime": "^0.4.1" } }, "sha512-4fT/28oF8VR99eJRK6jFw1YQ3X3KlKBt6fhfS/jFMq4OMQ2KOTUfLwLOTVGY3/utf1Am9mX359WBKYxdsIGoJA=="],
+    "@remix-run/fs": ["@remix-run/fs@0.4.5", "", { "dependencies": { "@remix-run/lazy-file": "^5.0.5", "@remix-run/mime": "^0.4.1" } }, "sha512-aruAQN2R//NQBeKg3YnovJ4JMZRmJ0pVWq3xoUMTeO16L6dCP82Al+dSizwGHy7ZavPfJwnlJHp5exTAhX5yCQ=="],
 
-    "@remix-run/headers": ["@remix-run/headers@0.19.0", "", {}, "sha512-+62NbkXuXm9r/NdG6KfH9OCKofCWm8VjkrVPICiHKtRl8Gf2Vi6eFTN4mGgBlZRhd5mmEVRV4hTIn/JUSHDAOw=="],
+    "@remix-run/headers": ["@remix-run/headers@0.21.1", "", {}, "sha512-DRhRveigepAQDUIi0MrOFhpcl3/KTv/fkpIhulv7Asv1pUwM8RpY2ENjdI8lfii6Z3MEsWtYhGt6If8bi6bYpQ=="],
 
-    "@remix-run/html-template": ["@remix-run/html-template@0.3.0", "", {}, "sha512-aAMx68udtIk0fmCpCXHYscVeCDsRVEmEgh4XvtusPr3vkHu3jn4gx5oAxgsPXPdDmmD/d75SYyI0m/F+aLz5iQ=="],
+    "@remix-run/html-template": ["@remix-run/html-template@0.3.1", "", {}, "sha512-4yhaBtfh1iVC1razTr+ehu1xmKia0zvE4GWQ6JF2IRiA3kmw+DlrdNFEFqx5Wn1eXAM0vxxcJLdLD7e0XMzH5A=="],
 
-    "@remix-run/lazy-file": ["@remix-run/lazy-file@5.0.3", "", { "dependencies": { "@remix-run/mime": "^0.4.1" } }, "sha512-3NIp4xRaxAwcDtRSXKm6qYeGX/DjFGNY4FVm0tdvvW2TFyuFbzBoYDQxo4PyEiLtlqkEaqqHTZTIe2SD+Dau+w=="],
+    "@remix-run/lazy-file": ["@remix-run/lazy-file@5.0.5", "", { "dependencies": { "@remix-run/mime": "^0.4.1" } }, "sha512-PhjTgR266T2qDKki6lQnlOtgZv4VB8Dqeu1sBUu2pBazgi2nZA2n7lvDpNiegKozBgGfUXS8ScdIQ6FPuNvtcw=="],
 
-    "@remix-run/logger-middleware": ["@remix-run/logger-middleware@0.2.1", "", { "dependencies": { "@remix-run/fetch-router": "^0.18.2", "@remix-run/terminal": "^0.1.0" } }, "sha512-V1suiosYzMhX6urHkmT4o4EgqCk7RpZjfovJ0vtTyHEYU8m66Wm9JrvqYjV0ws9wzyUjAVb8FGBqwq7HKRDWzQ=="],
+    "@remix-run/logger-middleware": ["@remix-run/logger-middleware@0.3.3", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.0", "@remix-run/terminal": "^0.1.1" } }, "sha512-nrKhWowr3PPimgwngx3U343ohS5noBTx1jgohMVP+3M0DxrQbJNppXu2qty93XZk4XGECj+DgQhU9U1O8ARLcA=="],
 
-    "@remix-run/method-override-middleware": ["@remix-run/method-override-middleware@0.1.7", "", { "dependencies": { "@remix-run/fetch-router": "^0.18.2" } }, "sha512-DOGYlVvh5E5ohwUOOjUBCMUwMYzMyfipiUeO+Ly9h5UPfIETWoCgaaVR+XxWXUfIm/9pPCD6DLeNPR8sXDz4ug=="],
+    "@remix-run/method-override-middleware": ["@remix-run/method-override-middleware@0.1.11", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.0" } }, "sha512-OP9yc33e3bEkjJ36YgVlUVuQcIUSLpFjjpDA7etK1qgRNE2EHBmVBR5ypqfGF2PORV0FnLvmAaeVpdz3eo/CNA=="],
 
     "@remix-run/mime": ["@remix-run/mime@0.4.1", "", {}, "sha512-n0DUUwpHiDrtHCSw6YFbjeMjajj7STqwzK9PMJkQOHbvOarfPdQdRRMkRqYPBmhu6ABzb6sAdYRSrxPx50I5VQ=="],
 
-    "@remix-run/multipart-parser": ["@remix-run/multipart-parser@0.16.0", "", { "dependencies": { "@remix-run/headers": "^0.19.0" } }, "sha512-RZqdkP+jOW3sQSsv/kC9OwaA0eifMEvTwlaIw/VC3HOHgebKgvQO/+gBJsBgH7YecFSbvaZq1/iB5J+1jVhDpg=="],
+    "@remix-run/multipart-parser": ["@remix-run/multipart-parser@0.16.3", "", { "dependencies": { "@remix-run/headers": "^0.21.1" } }, "sha512-XvMYPIyDTuquR7s1YF4wo4CqMPDrBkpWY0zHSa7SpX0F+t9awg7FWd5mJywc6vTn4oWeS7nQYQQarZ9CuoC/RQ=="],
 
-    "@remix-run/node-fetch-server": ["@remix-run/node-fetch-server@0.13.1", "", {}, "sha512-dOL+A/C84EA47gO/ps52KGrVSiYy96512rwtbXmJfWKYFm1FbrbjA3jao1hcIfao+jwVNEaZ1kTMwFjiino+HQ=="],
+    "@remix-run/node-fetch-server": ["@remix-run/node-fetch-server@0.13.3", "", {}, "sha512-UfjOXed/DQteaM5VyTfqTeGpHwyL2J5aoRGY6cydip4tt1ehNNeSwuXCC7AEGE0RWBs/7bgKxYkL/B/+UDe4AA=="],
 
-    "@remix-run/node-serve": ["@remix-run/node-serve@0.1.0", "", { "optionalDependencies": { "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.66.0" } }, "sha512-/OhPBuJkEswC7og5yHc5kG2JnOBHwWCXP4051X05K73Y7e7iAzcgjGz8eYaKNR5Lvk2uUmcECNelRdqNRxFSbg=="],
+    "@remix-run/node-tsx": ["@remix-run/node-tsx@0.1.1", "", { "dependencies": { "get-tsconfig": "^4.13.6", "oxc-transform": "^0.121.0" } }, "sha512-k9Oi2gML1E7c1PLj+kX+Hsumkjg9tpps7+ufpy7ugsiRTe6fDfZOyEmlYOIkfR2K2Nf8D33+967EMlInm9Nvvg=="],
 
-    "@remix-run/response": ["@remix-run/response@0.3.3", "", { "dependencies": { "@remix-run/headers": "^0.19.0", "@remix-run/html-template": "^0.3.0", "@remix-run/mime": "^0.4.1" } }, "sha512-hgqYDk557dYjLJ0W5Oa6cj5jtNc/5HpAV+jCYlW8+PvoO0gkQzwOJihaFbePCuGW7jhOAFeD4L+SlvV1TxvWpQ=="],
+    "@remix-run/render-middleware": ["@remix-run/render-middleware@0.1.3", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.0" } }, "sha512-wxrjRdYbiE7yT2VhCe1M7/ir4M44M6cxwnzCdxd8qVIg+i4lbFdizDR72ClDNoAQ2hPtlHDy7+2U+ufnNHUGRQ=="],
 
-    "@remix-run/route-pattern": ["@remix-run/route-pattern@0.20.1", "", {}, "sha512-SSwyX3hX/xZck5UXy0bN4ubsnRJeuEKqHjz4Cc3so32FECexdNk0Y+pg2YZNu7FLGpjBn5dBUQCOtjIXQQudUw=="],
+    "@remix-run/response": ["@remix-run/response@0.3.6", "", { "dependencies": { "@remix-run/headers": "^0.21.1", "@remix-run/html-template": "^0.3.1", "@remix-run/mime": "^0.4.1" } }, "sha512-WgbAXEGesrfVz449Lv1AUruT2r2t79XxkcG/cdzDZWXB/2UKcKFsVSM/tFvfmIuAtwdvhQrrnaFpnC04OfYSNA=="],
 
-    "@remix-run/session": ["@remix-run/session@0.4.1", "", {}, "sha512-Bm6aKYgutb/raHZ3laloz8g/Qu7f3CeK3o4gUVDMxtEiAdWCzJamwHoTpGOc5+g1Kuy7z85v4M6nGrF06MFDSg=="],
+    "@remix-run/route-pattern": ["@remix-run/route-pattern@0.22.1", "", {}, "sha512-czdGJWh09Lapvcqt7Vb09KlrU2PhRJ8xQaI+AItTuD9aDJ5MAgxnS38lnys6Ll+6RJEqPiaUqTwIQhVLwFvv+w=="],
 
-    "@remix-run/session-middleware": ["@remix-run/session-middleware@0.2.2", "", { "dependencies": { "@remix-run/cookie": "^0.5.1", "@remix-run/fetch-router": "^0.18.2", "@remix-run/session": "^0.4.1" } }, "sha512-JZVUoE2Ow/wOP4lOPdJIgXhgMEV2AZrYTv7+cEVDp4qzf2hZApVnAp2N4AcrNekSF24IRqz1Xm2gccHuHfIK8Q=="],
+    "@remix-run/session": ["@remix-run/session@0.4.2", "", {}, "sha512-NGzu6/gC5xD/tq40W0WqzTt4JhCdSCIwDHM1aa13JBqb4Ml/Mb0kmXqjfOe/gBYfu6AA11nRQ/BJyr+VduTodA=="],
 
-    "@remix-run/session-storage-memcache": ["@remix-run/session-storage-memcache@0.1.0", "", { "dependencies": { "@remix-run/session": "^0.4.1" } }, "sha512-k853rpHncdTJUwdk0hqd+gZ2OONZLNdOUJBKdJB+MehxrVv1TtacDnA+Xs3kh+IVwUrsTmBhED+GHSUocMATUg=="],
+    "@remix-run/session-middleware": ["@remix-run/session-middleware@0.3.3", "", { "dependencies": { "@remix-run/cookie": "^0.5.4", "@remix-run/fetch-router": "^0.20.0", "@remix-run/session": "^0.4.2" } }, "sha512-mMY3DJNpRAdEu6TMAVV0N6kGr3UCvucfunHHOzvWwMy7QVXqIgYFfJFIzWuHiKKGVUdNyBhDAADA3e9eLNtXRA=="],
 
-    "@remix-run/session-storage-redis": ["@remix-run/session-storage-redis@0.1.0", "", { "dependencies": { "@remix-run/session": "^0.4.1" }, "peerDependencies": { "redis": "^5.10.0" }, "optionalPeers": ["redis"] }, "sha512-MovUS1E98wDHP8zsESJGm3ySB7iiOhd+3usxyXXM2sbF9gIe6r1bdAXXirGIoC8AEq1v8IiFE5u5ipo7PX0UHQ=="],
+    "@remix-run/session-storage-memcache": ["@remix-run/session-storage-memcache@0.1.2", "", { "dependencies": { "@remix-run/session": "^0.4.2" } }, "sha512-VIJnz+DcJFo+vM1SRKy/8kbJHefVQtGyKS+V1AOMCk8OAMGCCyS+f4ERxmu3as48T/L55oBPsTxQX+rcPchDtQ=="],
 
-    "@remix-run/static-middleware": ["@remix-run/static-middleware@0.4.8", "", { "dependencies": { "@remix-run/fetch-router": "^0.18.2", "@remix-run/fs": "^0.4.3", "@remix-run/html-template": "^0.3.0", "@remix-run/mime": "^0.4.1", "@remix-run/response": "^0.3.3" } }, "sha512-dXU4MzxW/r+/btjittqXu7CeRU2IR0Z9G55pu241bh3i9fMOdtw2hhzVpUaNNfOPGsFCTq7KDIxo+dPKfTah0A=="],
+    "@remix-run/session-storage-redis": ["@remix-run/session-storage-redis@0.1.1", "", { "dependencies": { "@remix-run/session": "^0.4.2" }, "peerDependencies": { "redis": "^5.10.0" }, "optionalPeers": ["redis"] }, "sha512-y/dhJq5hs4rs1zCCPbPJp+i0/EBcYkwQLnwQ4mYtJbSjYIUklSqD3Z7+K8V/MJtl7B4fq8RD1m20lLjLSESMLw=="],
+
+    "@remix-run/static-middleware": ["@remix-run/static-middleware@0.4.12", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.0", "@remix-run/fs": "^0.4.5", "@remix-run/html-template": "^0.3.1", "@remix-run/mime": "^0.4.1", "@remix-run/response": "^0.3.6" } }, "sha512-ovppEYU9SdEzt7+jIZYN+ReD4LaWau2Vi98obAzgMdOfKBiP3C0ftdXhVmTBBtDq0kJdFoVi7NE/c95FpnGkwg=="],
 
     "@remix-run/tar-parser": ["@remix-run/tar-parser@0.7.1", "", {}, "sha512-NZKTuA66rj0zqpljWAb6v147cNu5BtRCiv8FY5kn64ZPvLmoI62Ehm2hoUh0g0wJHeCNmgS5QZg1xhw6FX67SA=="],
 
-    "@remix-run/terminal": ["@remix-run/terminal@0.1.0", "", {}, "sha512-vxiiCm3yQTBeG4j9Lm4PVZElEdD7gBNm+Q2rqTGMlE4ImrWFoq7h2Jk1y3BMylNZYz0m3pzihQ5G2sbY1XtdLg=="],
+    "@remix-run/terminal": ["@remix-run/terminal@0.1.1", "", {}, "sha512-M8JNcsYp/mWZ0yOB12Ir+Ud1eLxodPr8YSKQcG2PTPeiq9p9c59D9gvF9m6EU2Hmd4esJMiTyy6lJHc/VKKvcw=="],
 
-    "@remix-run/test": ["@remix-run/test@0.3.0", "", { "dependencies": { "@remix-run/terminal": "^0.1.0", "es-module-lexer": "^2.0.0", "esbuild": "^0.27.1", "get-tsconfig": "^4.13.6", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tsx": "^4.21.0", "v8-to-istanbul": "^9.3.0" }, "peerDependencies": { "playwright": "^1.59.0" }, "optionalPeers": ["playwright"], "bin": { "remix-test": "dist/cli-entry.js" } }, "sha512-amfWPIenHXXZqozPY+LUqspjmaSjHAW5J6jd4Owl180AEc+14IdMPy3D0x27S9ArjRioiqsPBKpYP1EmRft61g=="],
+    "@remix-run/test": ["@remix-run/test@0.5.0", "", { "dependencies": { "@remix-run/node-tsx": "^0.1.1", "@remix-run/terminal": "^0.1.1", "es-module-lexer": "^2.0.0", "esbuild": "^0.27.1", "get-tsconfig": "^4.13.6", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magic-string": "^0.30.21", "oxc-resolver": "^11.19.1", "source-map-js": "^1.2.1", "v8-to-istanbul": "^9.3.0" }, "peerDependencies": { "playwright": "^1.60.0" }, "optionalPeers": ["playwright"], "bin": { "remix-test": "dist/cli-entry.js" } }, "sha512-jaJLJi7+YXFh4JblWe3hjqve8tkiZ1Nzsog1j6EwCEv814bHldCqBbFrajI69DUULd3nNCs3Mk3rz96lt83xYA=="],
 
-    "@remix-run/ui": ["@remix-run/ui@0.1.1", "", { "dependencies": { "@types/dom-navigation": "^1.0.7" } }, "sha512-yn5oL/uZ8izabJxjeKhVo9lBGhb+ZhOJHWk5Tu7YJL3RSxvP7BrO/ofrdWUcOXSsNxao3Lj+PF1lVmnTBf8nfQ=="],
+    "@remix-run/ui": ["@remix-run/ui@0.3.0", "", { "dependencies": { "@types/dom-navigation": "^1.0.7" } }, "sha512-5zWmsnrls7UPioYg5vRNK3YQam5O3GGZBPONgi50f1Si3QPIdjNQvOEN2Qj1TcY3ehtLcsGgtBbba6AsXRR85A=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.12", "", { "os": "android", "cpu": "arm64" }, "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA=="],
 
@@ -1257,7 +1259,7 @@
 
     "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
 
-    "remix": ["remix@3.0.0-beta.0", "", { "dependencies": { "@remix-run/assert": "^0.2.0", "@remix-run/assets": "^0.3.0", "@remix-run/async-context-middleware": "^0.2.2", "@remix-run/auth": "^0.2.1", "@remix-run/auth-middleware": "^0.1.2", "@remix-run/cli": "^0.2.0", "@remix-run/compression-middleware": "^0.1.7", "@remix-run/cookie": "^0.5.1", "@remix-run/cop-middleware": "^0.1.2", "@remix-run/cors-middleware": "^0.1.2", "@remix-run/csrf-middleware": "^0.1.2", "@remix-run/data-schema": "^0.3.0", "@remix-run/data-table": "^0.2.1", "@remix-run/data-table-mysql": "^0.3.1", "@remix-run/data-table-postgres": "^0.3.1", "@remix-run/data-table-sqlite": "^0.4.1", "@remix-run/fetch-proxy": "^0.8.0", "@remix-run/fetch-router": "^0.18.2", "@remix-run/file-storage": "^0.13.4", "@remix-run/file-storage-s3": "^0.1.1", "@remix-run/form-data-middleware": "^0.2.3", "@remix-run/form-data-parser": "^0.17.0", "@remix-run/fs": "^0.4.3", "@remix-run/headers": "^0.19.0", "@remix-run/html-template": "^0.3.0", "@remix-run/lazy-file": "^5.0.3", "@remix-run/logger-middleware": "^0.2.1", "@remix-run/method-override-middleware": "^0.1.7", "@remix-run/mime": "^0.4.1", "@remix-run/multipart-parser": "^0.16.0", "@remix-run/node-fetch-server": "^0.13.1", "@remix-run/node-serve": "^0.1.0", "@remix-run/response": "^0.3.3", "@remix-run/route-pattern": "^0.20.1", "@remix-run/session": "^0.4.1", "@remix-run/session-middleware": "^0.2.2", "@remix-run/session-storage-memcache": "^0.1.0", "@remix-run/session-storage-redis": "^0.1.0", "@remix-run/static-middleware": "^0.4.8", "@remix-run/tar-parser": "^0.7.1", "@remix-run/terminal": "^0.1.0", "@remix-run/test": "^0.3.0", "@remix-run/ui": "^0.1.1" }, "peerDependencies": { "mysql2": "^3.15.3", "pg": "^8.16.3", "playwright": "^1.59.0", "redis": "^5.10.0" }, "optionalPeers": ["mysql2", "pg", "playwright", "redis"], "bin": { "remix": "dist/cli-entry.js" } }, "sha512-puVDlqsID9k1N7p+qb5IOLDeMlQ6WynU9qm2/iJAL+iX+1upgyaVzWeuLxNg761t9/Uh1u1tT/PuaaRTi932Tg=="],
+    "remix": ["remix@3.0.0-beta.4", "", { "dependencies": { "@remix-run/assert": "^0.3.0", "@remix-run/assets": "^0.4.3", "@remix-run/async-context-middleware": "^0.3.3", "@remix-run/auth": "^0.2.5", "@remix-run/auth-middleware": "^0.2.3", "@remix-run/cli": "^0.3.3", "@remix-run/compression-middleware": "^0.1.11", "@remix-run/cookie": "^0.5.4", "@remix-run/cop-middleware": "^0.1.6", "@remix-run/cors-middleware": "^0.1.6", "@remix-run/csrf-middleware": "^0.1.6", "@remix-run/data-schema": "^0.3.0", "@remix-run/data-table": "^0.3.0", "@remix-run/data-table-mysql": "^0.4.0", "@remix-run/data-table-postgres": "^0.4.0", "@remix-run/data-table-sqlite": "^0.5.1", "@remix-run/fetch-proxy": "^0.8.3", "@remix-run/fetch-router": "^0.20.0", "@remix-run/file-storage": "^0.13.6", "@remix-run/file-storage-s3": "^0.1.3", "@remix-run/form-data-middleware": "^0.3.3", "@remix-run/form-data-parser": "^0.17.3", "@remix-run/fs": "^0.4.5", "@remix-run/headers": "^0.21.1", "@remix-run/html-template": "^0.3.1", "@remix-run/lazy-file": "^5.0.5", "@remix-run/logger-middleware": "^0.3.3", "@remix-run/method-override-middleware": "^0.1.11", "@remix-run/mime": "^0.4.1", "@remix-run/multipart-parser": "^0.16.3", "@remix-run/node-fetch-server": "^0.13.3", "@remix-run/node-tsx": "^0.1.1", "@remix-run/render-middleware": "^0.1.3", "@remix-run/response": "^0.3.6", "@remix-run/route-pattern": "^0.22.1", "@remix-run/session": "^0.4.2", "@remix-run/session-middleware": "^0.3.3", "@remix-run/session-storage-memcache": "^0.1.2", "@remix-run/session-storage-redis": "^0.1.1", "@remix-run/static-middleware": "^0.4.12", "@remix-run/tar-parser": "^0.7.1", "@remix-run/terminal": "^0.1.1", "@remix-run/test": "^0.5.0", "@remix-run/ui": "^0.3.0" }, "peerDependencies": { "mysql2": "^3.15.3", "pg": "^8.16.3", "playwright": "^1.60.0", "redis": "^5.10.0" }, "optionalPeers": ["mysql2", "pg", "playwright", "redis"], "bin": { "remix": "dist/cli-entry.js" } }, "sha512-KT3elI5Xqbsuy17EXyAicM4aOrbReMMu4ozwRVGxe+XYu7IiZ0q4ScCHUg2MLRrazADLewbZLIODrK61LGMfwg=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
@@ -1388,8 +1390,6 @@
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "typescript-eslint": ["typescript-eslint@8.54.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.54.0", "@typescript-eslint/parser": "8.54.0", "@typescript-eslint/typescript-estree": "8.54.0", "@typescript-eslint/utils": "8.54.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-CKsJ+g53QpsNPqbzUsfKVgd3Lny4yKZ1pP4qN3jdMOg/sisIDLGyDMezycquXLE5JsEU0wp3dGNdzig0/fmSVQ=="],
-
-    "uWebSockets.js": ["uWebSockets.js@github:uNetworking/uWebSockets.js#a63031f", {}, "uNetworking-uWebSockets.js-a63031f", "sha512-WacEEsHYOHOsgYhForV9GKpdXDnAV9nqJdxZyAyRQS9gXrP0xrARf6eyesMVFJodvFZ9dzv89pdhBPey54NtbQ=="],
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 

--- a/client/editable-text.tsx
+++ b/client/editable-text.tsx
@@ -17,7 +17,7 @@ const inheritTextStyles = {
 	lineHeight: 'inherit',
 	color: 'inherit',
 } as const
-export function EditableText(handle: Handle) {
+export function EditableText(handle: Handle<EditableTextProps>) {
 	let isEditing = false
 	let draftValue = ''
 	let isSaving = false
@@ -36,7 +36,8 @@ export function EditableText(handle: Handle) {
 			button.focus()
 		})
 	}
-	return (props: EditableTextProps) => {
+	return () => {
+		const props = handle.props
 		const buttonId = `${props.id}-button`
 		function startEditing() {
 			if (isSaving) return

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@modelcontextprotocol/sdk": "1.26.0",
     "agents": "^0.7.6",
     "get-port": "^7.1.0",
-    "remix": "3.0.0-beta.0",
+    "remix": "3.0.0-beta.4",
     "workers-ai-provider": "^3.1.2",
     "zod": "^4.3.6"
   }

--- a/server/handlers/account.ts
+++ b/server/handlers/account.ts
@@ -1,4 +1,4 @@
-import { type BuildAction } from 'remix/fetch-router'
+import { type Action } from 'remix/router'
 import { readAuthSessionResult } from '#server/auth-session.ts'
 import { redirectToLogin } from '#server/auth-redirect.ts'
 import { Layout } from '#server/layout.ts'
@@ -25,7 +25,4 @@ export const account = {
 
 		return response
 	},
-} satisfies BuildAction<
-	typeof routes.account.method,
-	typeof routes.account.pattern
->
+} satisfies Action<typeof routes.account>

--- a/server/handlers/auth-handler.test.ts
+++ b/server/handlers/auth-handler.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="bun" />
 import { beforeAll, expect, test } from 'vitest'
-import { RequestContext } from 'remix/fetch-router'
+import { RequestContext } from 'remix/router'
 import { setAuthSessionSecret } from '#server/auth-session.ts'
 import { createPasswordHash } from '#server/password-hash.ts'
 import { createAuthHandler } from './auth.ts'

--- a/server/handlers/auth.ts
+++ b/server/handlers/auth.ts
@@ -1,4 +1,4 @@
-import { type BuildAction } from 'remix/fetch-router'
+import { type Action } from 'remix/router'
 import { enum_, object, parseSafe, string } from 'remix/data-schema'
 import { createAuthCookie, isSecureRequest } from '#server/auth-session.ts'
 import { getRequestIp, logAuditEvent } from '#server/audit-log.ts'
@@ -235,5 +235,5 @@ export function createAuthHandler(appEnv: AppEnv) {
 				},
 			)
 		},
-	} satisfies BuildAction<typeof routes.auth.method, typeof routes.auth.pattern>
+	} satisfies Action<typeof routes.auth>
 }

--- a/server/handlers/chat-threads.ts
+++ b/server/handlers/chat-threads.ts
@@ -1,4 +1,4 @@
-import { type BuildAction } from 'remix/fetch-router'
+import { type Action } from 'remix/router'
 import { readAuthenticatedAppUser } from '#server/authenticated-user.ts'
 import { type routes } from '#server/routes.ts'
 import { createChatThreadsStore } from '#server/chat-threads.ts'
@@ -58,10 +58,7 @@ export function createChatThreadsHandler(appEnv: AppEnv) {
 			const thread = await store.createForUser(user.userId)
 			return jsonResponse({ ok: true, thread }, { status: 201 })
 		},
-	} satisfies BuildAction<
-		typeof routes.chatThreadsCreate.method | typeof routes.chatThreads.method,
-		typeof routes.chatThreads.pattern
-	>
+	} satisfies Action<typeof routes.chatThreads>
 }
 
 export function createDeleteChatThreadHandler(appEnv: AppEnv) {
@@ -111,10 +108,7 @@ export function createDeleteChatThreadHandler(appEnv: AppEnv) {
 
 			return jsonResponse({ ok: true })
 		},
-	} satisfies BuildAction<
-		typeof routes.chatThreadsDelete.method,
-		typeof routes.chatThreadsDelete.pattern
-	>
+	} satisfies Action<typeof routes.chatThreadsDelete>
 }
 
 export function createUpdateChatThreadHandler(appEnv: AppEnv) {
@@ -176,8 +170,5 @@ export function createUpdateChatThreadHandler(appEnv: AppEnv) {
 
 			return jsonResponse({ ok: true, thread })
 		},
-	} satisfies BuildAction<
-		typeof routes.chatThreadsUpdate.method,
-		typeof routes.chatThreadsUpdate.pattern
-	>
+	} satisfies Action<typeof routes.chatThreadsUpdate>
 }

--- a/server/handlers/chat.ts
+++ b/server/handlers/chat.ts
@@ -1,4 +1,4 @@
-import { type BuildAction } from 'remix/fetch-router'
+import { type Action } from 'remix/router'
 import { readAuthSessionResult } from '#server/auth-session.ts'
 import { redirectToLogin } from '#server/auth-redirect.ts'
 import { Layout } from '#server/layout.ts'
@@ -21,4 +21,4 @@ export const chat = {
 
 		return response
 	},
-} satisfies BuildAction<typeof routes.chat.method, typeof routes.chat.pattern>
+} satisfies Action<typeof routes.chat>

--- a/server/handlers/health-handler.test.ts
+++ b/server/handlers/health-handler.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="bun" />
 import { expect, test } from 'vitest'
-import { RequestContext } from 'remix/fetch-router'
+import { RequestContext } from 'remix/router'
 import { createHealthHandler } from './health.ts'
 
 function createHealthRequestContext() {

--- a/server/handlers/health.ts
+++ b/server/handlers/health.ts
@@ -1,4 +1,4 @@
-import { type BuildAction } from 'remix/fetch-router'
+import { type Action } from 'remix/router'
 import { type routes } from '#server/routes.ts'
 import { type AppEnv } from '#types/env-schema.ts'
 
@@ -21,8 +21,5 @@ export function createHealthHandler(appEnv: HealthEnv) {
 				},
 			)
 		},
-	} satisfies BuildAction<
-		typeof routes.health.method,
-		typeof routes.health.pattern
-	>
+	} satisfies Action<typeof routes.health>
 }

--- a/server/handlers/home.ts
+++ b/server/handlers/home.ts
@@ -1,4 +1,4 @@
-import { type BuildAction } from 'remix/fetch-router'
+import { type Action } from 'remix/router'
 import { Layout } from '#server/layout.ts'
 import { render } from '#server/render.ts'
 import { type routes } from '#server/routes.ts'
@@ -8,4 +8,4 @@ export const home = {
 	async handler() {
 		return render(Layout({}))
 	},
-} satisfies BuildAction<typeof routes.home.method, typeof routes.home.pattern>
+} satisfies Action<typeof routes.home>

--- a/server/handlers/login.ts
+++ b/server/handlers/login.ts
@@ -2,4 +2,6 @@ import { type Action } from 'remix/router'
 import { type routes } from '#server/routes.ts'
 import { createAuthPageHandler } from './auth-page.ts'
 
-export const login = createAuthPageHandler() satisfies Action<typeof routes.login>
+export const login = createAuthPageHandler() satisfies Action<
+	typeof routes.login
+>

--- a/server/handlers/login.ts
+++ b/server/handlers/login.ts
@@ -1,8 +1,5 @@
-import { type BuildAction } from 'remix/fetch-router'
+import { type Action } from 'remix/router'
 import { type routes } from '#server/routes.ts'
 import { createAuthPageHandler } from './auth-page.ts'
 
-export const login = createAuthPageHandler() satisfies BuildAction<
-	typeof routes.login.method,
-	typeof routes.login.pattern
->
+export const login = createAuthPageHandler() satisfies Action<typeof routes.login>

--- a/server/handlers/logout.ts
+++ b/server/handlers/logout.ts
@@ -1,4 +1,4 @@
-import { type BuildAction } from 'remix/fetch-router'
+import { type Action } from 'remix/router'
 import { destroyAuthCookie, isSecureRequest } from '#server/auth-session.ts'
 import { type routes } from '#server/routes.ts'
 
@@ -16,7 +16,4 @@ export const logout = {
 			},
 		})
 	},
-} satisfies BuildAction<
-	typeof routes.logout.method,
-	typeof routes.logout.pattern
->
+} satisfies Action<typeof routes.logout>

--- a/server/handlers/password-reset.ts
+++ b/server/handlers/password-reset.ts
@@ -1,4 +1,4 @@
-import { type BuildAction } from 'remix/fetch-router'
+import { type Action } from 'remix/router'
 import { object, parseSafe, string } from 'remix/data-schema'
 import { type AppEnv } from '#types/env-schema.ts'
 import { createDb, passwordResetsTable, usersTable } from '#worker/db.ts'
@@ -181,10 +181,7 @@ export function createPasswordResetRequestHandler(appEnv: AppEnv) {
 				message: 'If the account exists, a reset email has been sent.',
 			})
 		},
-	} satisfies BuildAction<
-		typeof routes.passwordResetRequest.method,
-		typeof routes.passwordResetRequest.pattern
-	>
+	} satisfies Action<typeof routes.passwordResetRequest>
 }
 
 export function createPasswordResetConfirmHandler(appEnv: AppEnv) {
@@ -265,8 +262,5 @@ export function createPasswordResetConfirmHandler(appEnv: AppEnv) {
 
 			return Response.json({ ok: true })
 		},
-	} satisfies BuildAction<
-		typeof routes.passwordResetConfirm.method,
-		typeof routes.passwordResetConfirm.pattern
-	>
+	} satisfies Action<typeof routes.passwordResetConfirm>
 }

--- a/server/handlers/session-handler.test.ts
+++ b/server/handlers/session-handler.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="bun" />
 import { beforeAll, expect, test } from 'vitest'
-import { RequestContext } from 'remix/fetch-router'
+import { RequestContext } from 'remix/router'
 import {
 	createAuthCookie,
 	setAuthSessionSecret,

--- a/server/handlers/session.ts
+++ b/server/handlers/session.ts
@@ -1,4 +1,4 @@
-import { type BuildAction } from 'remix/fetch-router'
+import { type Action } from 'remix/router'
 import { readAuthSessionResult } from '#server/auth-session.ts'
 import { type routes } from '#server/routes.ts'
 
@@ -32,7 +32,4 @@ export const session = {
 				: undefined,
 		)
 	},
-} satisfies BuildAction<
-	typeof routes.session.method,
-	typeof routes.session.pattern
->
+} satisfies Action<typeof routes.session>

--- a/server/handlers/signup.ts
+++ b/server/handlers/signup.ts
@@ -1,8 +1,7 @@
-import { type BuildAction } from 'remix/fetch-router'
+import { type Action } from 'remix/router'
 import { type routes } from '#server/routes.ts'
 import { createAuthPageHandler } from './auth-page.ts'
 
-export const signup = createAuthPageHandler() satisfies BuildAction<
-	typeof routes.signup.method,
-	typeof routes.signup.pattern
+export const signup = createAuthPageHandler() satisfies Action<
+	typeof routes.signup
 >

--- a/server/router.ts
+++ b/server/router.ts
@@ -1,4 +1,4 @@
-import { createRouter } from 'remix/fetch-router'
+import { createRouter } from 'remix/router'
 import { type AppEnv } from '#types/env-schema.ts'
 import { account } from './handlers/account.ts'
 import { createAuthHandler } from './handlers/auth.ts'

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,4 +1,4 @@
-import { post, route } from 'remix/fetch-router/routes'
+import { post, route } from 'remix/routes'
 
 export const routes = route({
 	home: '/',

--- a/worker/d1-data-table-adapter.ts
+++ b/worker/d1-data-table-adapter.ts
@@ -6,9 +6,6 @@ import {
 	type DataManipulationOperation,
 	type DataManipulationRequest,
 	type DataManipulationResult,
-	type DataMigrationOperation,
-	type DataMigrationRequest,
-	type DataMigrationResult,
 	type SqlStatement,
 	type TableRef,
 	type DatabaseAdapter,
@@ -76,21 +73,8 @@ export class D1DataTableAdapter implements DatabaseAdapter {
 		}
 	}
 
-	compileSql(
-		operation: DataManipulationOperation | DataMigrationOperation,
-	): Array<SqlStatement> {
-		const statement =
-			operation.kind === 'raw' ||
-			operation.kind === 'select' ||
-			operation.kind === 'count' ||
-			operation.kind === 'exists' ||
-			operation.kind === 'insert' ||
-			operation.kind === 'insertMany' ||
-			operation.kind === 'update' ||
-			operation.kind === 'delete' ||
-			operation.kind === 'upsert'
-				? compileSqliteStatement(operation)
-				: compileSqliteMigrationStatement(operation)
+	compileSql(operation: DataManipulationOperation): Array<SqlStatement> {
+		const statement = compileSqliteStatement(operation)
 		return [{ text: statement.text, values: statement.values }]
 	}
 
@@ -155,15 +139,8 @@ export class D1DataTableAdapter implements DatabaseAdapter {
 		}
 	}
 
-	async migrate(request: DataMigrationRequest): Promise<DataMigrationResult> {
-		const statements = this.compileSql(request.operation)
-		for (const statement of statements) {
-			await this.#database
-				.prepare(statement.text)
-				.bind(...statement.values)
-				.run()
-		}
-		return { affectedOperations: 1 }
+	async executeScript(sql: string, _transaction?: TransactionToken): Promise<void> {
+		await this.#database.exec(sql)
 	}
 
 	async hasTable(table: TableRef): Promise<boolean> {
@@ -501,131 +478,6 @@ function compileSqliteStatement(
 	}
 
 	throw new Error('Unsupported statement kind')
-}
-
-function compileSqliteMigrationStatement(
-	operation: DataMigrationRequest['operation'],
-): CompiledSqlStatement {
-	if (operation.kind === 'raw') {
-		return {
-			text: operation.sql.text,
-			values: [...operation.sql.values],
-		}
-	}
-
-	if (operation.kind === 'createTable') {
-		const columnDefinitions = Object.entries(operation.columns).map(
-			([name, definition]) =>
-				quotePath(name) + ' ' + compileColumnDefinition(definition),
-		)
-		const constraints: Array<string> = []
-		if (operation.primaryKey) {
-			const columns = operation.primaryKey.columns
-				.map((column) => quotePath(column))
-				.join(', ')
-			const name = operation.primaryKey.name
-				? 'constraint ' + quotePath(operation.primaryKey.name) + ' '
-				: ''
-			constraints.push(name + 'primary key (' + columns + ')')
-		}
-		for (const unique of operation.uniques ?? []) {
-			const columns = unique.columns
-				.map((column) => quotePath(column))
-				.join(', ')
-			const name = unique.name
-				? 'constraint ' + quotePath(unique.name) + ' '
-				: ''
-			constraints.push(name + 'unique (' + columns + ')')
-		}
-		return {
-			text:
-				'create table ' +
-				(operation.ifNotExists ? 'if not exists ' : '') +
-				quoteTableRef(operation.table) +
-				' (' +
-				[...columnDefinitions, ...constraints].join(', ') +
-				')',
-			values: [],
-		}
-	}
-
-	if (operation.kind === 'dropTable') {
-		return {
-			text:
-				'drop table ' +
-				(operation.ifExists ? 'if exists ' : '') +
-				quoteTableRef(operation.table),
-			values: [],
-		}
-	}
-
-	if (operation.kind === 'createIndex') {
-		const index = operation.index
-		const unique = index.unique ? 'unique ' : ''
-		const columns = index.columns.map((column) => quotePath(column)).join(', ')
-		const where = index.where ? ' where ' + index.where : ''
-		return {
-			text:
-				'create ' +
-				unique +
-				'index ' +
-				(operation.ifNotExists ? 'if not exists ' : '') +
-				quotePath(index.name) +
-				' on ' +
-				quoteTableRef(index.table) +
-				' (' +
-				columns +
-				')' +
-				where,
-			values: [],
-		}
-	}
-
-	if (operation.kind === 'dropIndex') {
-		return {
-			text:
-				'drop index ' +
-				(operation.ifExists ? 'if exists ' : '') +
-				quotePath(operation.name),
-			values: [],
-		}
-	}
-
-	if (operation.kind === 'alterTable') {
-		if (operation.changes.length !== 1) {
-			throw new Error('D1 adapter supports one alter-table change at a time')
-		}
-		const change = operation.changes[0]
-		if (!change) {
-			throw new Error('alterTable requires at least one change')
-		}
-		if (change.kind === 'addColumn') {
-			return {
-				text:
-					'alter table ' +
-					quoteTableRef(operation.table) +
-					' add column ' +
-					quotePath(change.column) +
-					' ' +
-					compileColumnDefinition(change.definition),
-				values: [],
-			}
-		}
-		if (change.kind === 'renameColumn') {
-			return {
-				text:
-					'alter table ' +
-					quoteTableRef(operation.table) +
-					' rename column ' +
-					quotePath(change.from) +
-					' to ' +
-					quotePath(change.to),
-				values: [],
-			}
-		}
-	}
-
-	throw new Error('Unsupported D1 migration operation: ' + operation.kind)
 }
 
 function compileInsertStatement(
@@ -1043,49 +895,6 @@ function quotePath(path: string) {
 			return quoteIdentifier(segment)
 		})
 		.join('.')
-}
-
-function quoteTableRef(table: TableRef) {
-	return table.schema
-		? quotePath(table.schema + '.' + table.name)
-		: quotePath(table.name)
-}
-
-function compileColumnDefinition(definition: {
-	type: string
-	nullable?: boolean
-	primaryKey?: boolean
-	unique?: boolean | { name?: string }
-	default?: unknown
-	autoIncrement?: boolean
-	length?: number
-	precision?: number
-	scale?: number
-}) {
-	const parts = [compileColumnType(definition)]
-	if (definition.primaryKey) parts.push('primary key')
-	if (definition.autoIncrement) parts.push('autoincrement')
-	if (definition.nullable === false) parts.push('not null')
-	if (definition.unique) parts.push('unique')
-	return parts.join(' ')
-}
-
-function compileColumnType(definition: {
-	type: string
-	length?: number
-	precision?: number
-	scale?: number
-}) {
-	if (definition.type === 'integer' || definition.type === 'bigint')
-		return 'integer'
-	if (definition.type === 'decimal') {
-		return definition.precision === undefined
-			? 'real'
-			: `decimal(${definition.precision}, ${definition.scale ?? 0})`
-	}
-	if (definition.type === 'boolean') return 'integer'
-	if (definition.type === 'binary') return 'blob'
-	return 'text'
 }
 
 function pushValue(context: SqliteCompileContext, value: unknown) {

--- a/worker/d1-data-table-adapter.ts
+++ b/worker/d1-data-table-adapter.ts
@@ -139,7 +139,10 @@ export class D1DataTableAdapter implements DatabaseAdapter {
 		}
 	}
 
-	async executeScript(sql: string, _transaction?: TransactionToken): Promise<void> {
+	async executeScript(
+		sql: string,
+		_transaction?: TransactionToken,
+	): Promise<void> {
 		await this.#database.exec(sql)
 	}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Upgrade `remix` from `3.0.0-beta.0` to `3.0.0-beta.4`.
- Migrate server route/action imports to the beta.1+ `remix/router` and `remix/routes` subpaths.
- Replace removed `BuildAction` annotations with public `Action<typeof routes...>` contracts.
- Adapt Remix UI components to read render props from `handle.props`.
- Update the custom D1 data-table adapter for plain-SQL migration scripts via `executeScript(sql)` and remove the old schema-builder migration compiler.

## Walkthrough

<a href="https://cursor.com/agents/bc-9e8c5ab1-7ac7-4d1b-a8bb-6521ddde4a6b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fremix-beta-4-chat-title-rename.mp4"><img src="https://cursor.com/artifacts/c/art-fe2f774f-9ac3-41b8-b5f9-c6986635b9fa" alt="remix-beta-4-chat-title-rename.mp4" /></a>

![Updated chat title after Remix beta 4 walkthrough](https://cursor.com/artifacts/c/art-2d4c5582-cb2f-4bff-9132-59e3f43f1ad5)

## Notes

- Reviewed beta.1 through beta.4 release notes plus `fetch-router@0.20.0`, `ui@0.3.0`, `data-table@0.3.0`, `test@0.5.0`, and `assert@0.3.0` package notes.
- `router.mount()` was considered but not applied because this app currently has one flat route contract used by both server and client code; adding mounted groups would not reduce complexity in this shape.

## Testing

- `bunx prettier --check package.json server/router.ts server/routes.ts server/handlers/account.ts server/handlers/auth-handler.test.ts server/handlers/auth.ts server/handlers/chat-threads.ts server/handlers/chat.ts server/handlers/health-handler.test.ts server/handlers/health.ts server/handlers/home.ts server/handlers/login.ts server/handlers/logout.ts server/handlers/password-reset.ts server/handlers/session-handler.test.ts server/handlers/session.ts server/handlers/signup.ts client/editable-text.tsx worker/d1-data-table-adapter.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run test:unit`
- `PLAYWRIGHT_BASE_URL=http://localhost:3742 PLAYWRIGHT_PORT=3742 bun run test:e2e e2e/chat.spec.ts`
- `PLAYWRIGHT_BASE_URL=http://localhost:3742 PLAYWRIGHT_PORT=3742 bun run test:e2e`
- `bun run test:mcp`
- Manual browser walkthrough: login, create chat, rename chat title with the upgraded `EditableText` component.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e8c5ab1-7ac7-4d1b-a8bb-6521ddde4a6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e8c5ab1-7ac7-4d1b-a8bb-6521ddde4a6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

