### PR TITLE
Update Remix to 3.0.0-beta.5

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "@modelcontextprotocol/sdk": "1.26.0",
         "agents": "^0.7.6",
         "get-port": "^7.1.0",
-        "remix": "3.0.0-beta.4",
+        "remix": "3.0.0-beta.5",
         "workers-ai-provider": "^3.1.2",
         "zod": "^4.3.6",
       },
@@ -473,25 +473,25 @@
 
     "@remix-run/assert": ["@remix-run/assert@0.3.0", "", {}, "sha512-GBA9klvJdG5YSTwRNur54LQcfqDOtir+x1TDbv3dzB9FS2Li9CEiRLp1EpBcaYrj4ByO03WJCWFBiY8bTMy4vQ=="],
 
-    "@remix-run/assets": ["@remix-run/assets@0.4.3", "", { "dependencies": { "@oxc-project/runtime": "^0.121.0", "@remix-run/file-storage": "0.13.6", "@remix-run/headers": "0.21.1", "@remix-run/mime": "0.4.1", "@remix-run/route-pattern": "0.22.1", "chokidar": "^5.0.0", "es-module-lexer": "^2.0.0", "get-tsconfig": "^4.13.6", "lightningcss": "^1.32.0", "magic-string": "^0.30.21", "oxc-minify": "^0.121.0", "oxc-parser": "^0.121.0", "oxc-resolver": "^11.19.1", "oxc-transform": "^0.121.0", "picomatch": "^4.0.4", "source-map-js": "^1.2.1" } }, "sha512-3YKANQIc/dATxy9+7VpaILXZ4KPOP7y888EbyAphvEu++jOILpjHxMi5N+fhXoRZxpmL+CXaB7PKEwbsAAnKpA=="],
+    "@remix-run/assets": ["@remix-run/assets@0.4.4", "", { "dependencies": { "@oxc-project/runtime": "^0.121.0", "@remix-run/file-storage": "0.13.7", "@remix-run/headers": "0.21.1", "@remix-run/mime": "0.4.2", "@remix-run/route-pattern": "0.23.0", "chokidar": "^5.0.0", "es-module-lexer": "^2.0.0", "get-tsconfig": "^4.13.6", "lightningcss": "^1.32.0", "magic-string": "^0.30.21", "oxc-minify": "^0.121.0", "oxc-parser": "^0.121.0", "oxc-resolver": "^11.19.1", "oxc-transform": "^0.121.0", "picomatch": "^4.0.4", "source-map-js": "^1.2.1" } }, "sha512-RvENzqsz4avj+PuBRy4AarY0JVGzacy7v9VH/LQuP14xpLPjC134hvKcQJNPkc8vV83d7r8WA/5JXcEESqyiUQ=="],
 
-    "@remix-run/async-context-middleware": ["@remix-run/async-context-middleware@0.3.3", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.0" } }, "sha512-Qg53vPttFVX9kxYjn8dxd+/BpCCe9gaYGPUze+YAMvQ73InKyeTF1a4zqnmHgHxTVp2qYK+kp0derTVlRAMTpQ=="],
+    "@remix-run/async-context-middleware": ["@remix-run/async-context-middleware@0.3.4", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.1" } }, "sha512-AxFFj2z4z7xdSedRIbtD9WUXLlWDeUox1v6d4x/SInbkiUF+C9LoTZyqh4QSI15bOUrpK1NNVCUCTCgfw4LR0A=="],
 
-    "@remix-run/auth": ["@remix-run/auth@0.2.5", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.0", "@remix-run/session": "^0.4.2" } }, "sha512-liwLro3rHgtjTc3MuYD4iKlZUcVvAzZUSGk0Tc1JFd7QSI8E8G2QeCxJvZRpul6TO0ojnjSogNydmj42ZpI4iQ=="],
+    "@remix-run/auth": ["@remix-run/auth@0.2.6", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.1", "@remix-run/session": "^0.4.2" } }, "sha512-7oRSZftQPvYN5vSk89vSZlJHR8iWyLLYTO1Hh6DZ4PI7nCO4V3i4WuHBzog3QajLJCCVhQnEt/o2SuPTBOTXGQ=="],
 
-    "@remix-run/auth-middleware": ["@remix-run/auth-middleware@0.2.3", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.0", "@remix-run/session": "^0.4.2" } }, "sha512-dUt/b/Vj4dntpORbQ9bV51eWyi7DyHM7zV4EfbSGsw7jyYfwtRptqu5Y3gAW6YlGAM1jp+ahSUMSzOqb1EEKWw=="],
+    "@remix-run/auth-middleware": ["@remix-run/auth-middleware@0.2.4", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.1", "@remix-run/session": "^0.4.2" } }, "sha512-REesK8+OiX+kVwSvwSnpEzLWxQnekTGASNU049ygfGxDh9ow/2jC5BZ445muHenkV0qcCIsSlQYiUj5dDXIAYw=="],
 
-    "@remix-run/cli": ["@remix-run/cli@0.3.3", "", { "dependencies": { "@remix-run/terminal": "^0.1.1", "@remix-run/test": "^0.5.0", "semver": "^7.7.4" } }, "sha512-3ho5CuzpIA6IIyY48EvAsA5I2c5mlT6RNvGa5/oSi6OutgNX+Fb9UDLIw7MbvKRvaIL6b/XOHT0LCQ+TrIAL+g=="],
+    "@remix-run/cli": ["@remix-run/cli@0.3.4", "", { "dependencies": { "@remix-run/terminal": "^0.1.1", "@remix-run/test": "^0.5.0", "semver": "^7.7.4" } }, "sha512-1yzvqQyuBLAK+I8oNiY5Vxz5M2+oqUrkFtR2F6aEu45lVI5iSsvSw/XQicuvAHJg970aIpu2FlYUc7ZhZOKylw=="],
 
-    "@remix-run/compression-middleware": ["@remix-run/compression-middleware@0.1.11", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.0", "@remix-run/mime": "^0.4.1", "@remix-run/response": "^0.3.6" } }, "sha512-VgnCV8cZqH11HhBXqIbgskUaK7ORkFlVBy9I+6dQQKWpDv/WnouFtKI2anlAfYqUZ+6WCfyBTNlq5FfbAz5lVA=="],
+    "@remix-run/compression-middleware": ["@remix-run/compression-middleware@0.1.12", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.1", "@remix-run/mime": "^0.4.2", "@remix-run/response": "^0.3.7" } }, "sha512-jThJMui3ca0vvXNTOIiozpyeFVTrabU5bhCjIjQuFKevCtMf9BJi3u+MDABzwxxyH+ztW59rv8R+IJ5O4/nMFA=="],
 
     "@remix-run/cookie": ["@remix-run/cookie@0.5.4", "", { "dependencies": { "@remix-run/headers": "^0.21.1" } }, "sha512-QxV2yo0umBXxwMub8kZFC+nOFnGMVpGo3jQ1Gvs4p1n2N7/0LAKhPgKsWbsk5ab6EqVhpr0S+v9gSQON1nuyoA=="],
 
-    "@remix-run/cop-middleware": ["@remix-run/cop-middleware@0.1.6", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.0" } }, "sha512-KPTHCIunLQxzNHXPel0jYFpKcmM7TF9GxMaitV0NGh8JktRDX0ckS+6lpHk7gGf06lIBYcafgqwrIVdp/LXSXg=="],
+    "@remix-run/cop-middleware": ["@remix-run/cop-middleware@0.1.7", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.1" } }, "sha512-B3UEE2ob4GNG6eQilEhqUygCK7t7oPqpNfAtCqhoN+R+LBsdi+9+re5wHaT3xNTa4eeT6YqyXnQsQX6A4otzyg=="],
 
-    "@remix-run/cors-middleware": ["@remix-run/cors-middleware@0.1.6", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.0", "@remix-run/headers": "^0.21.1" } }, "sha512-n4+sL7ePUhtWKrTjSfjs37sgz228cZPQbSyOEPy6b8nGhX8cRDFYqkF3M9BSelxoP4sWfIQZTaE1LTGAemHrrA=="],
+    "@remix-run/cors-middleware": ["@remix-run/cors-middleware@0.1.7", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.1", "@remix-run/headers": "^0.21.1" } }, "sha512-zbjwCFDwtHDSjyt6sgVVPkFiFfSkmkYPT74nrHClbF+pZx1ra+q93Rpcthbok0cv4IH1f0cagLbf8Jh+IEWNwA=="],
 
-    "@remix-run/csrf-middleware": ["@remix-run/csrf-middleware@0.1.6", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.0", "@remix-run/session": "^0.4.2" } }, "sha512-qqF92bQFwKu3qnLvMjFPhf6B0gHr4U4ZolLFcfOVgK8OcszHZQdBCLwmwGu+G6MxbaNnk0OtE+kL36liJ5+Tzw=="],
+    "@remix-run/csrf-middleware": ["@remix-run/csrf-middleware@0.1.7", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.1", "@remix-run/session": "^0.4.2" } }, "sha512-+AUUVIlDEEp62JCyLWC6+pQ7BqaZ2lSkxrBFK/l3t3YYsuA30yk6aPpbQXBXLBtHI12eWA2PHAFZxeRrCPHphQ=="],
 
     "@remix-run/data-schema": ["@remix-run/data-schema@0.3.0", "", { "dependencies": { "@standard-schema/spec": "^1.1.0" } }, "sha512-rjGaFJduzO3iMFOKwA5URpZDuGbUxgBwcX9myBglfqbax8dBlhRcxurydepq+xi+XBE+bPrT9V57Jur6p1igow=="],
 
@@ -503,53 +503,53 @@
 
     "@remix-run/data-table-sqlite": ["@remix-run/data-table-sqlite@0.5.1", "", { "dependencies": { "@remix-run/data-table": "^0.3.0" } }, "sha512-YgpUz49eeddYHOY3ebWi4Xeu94KWICRPrmsotkWpTIQdnf/sV+Ddx8BS4kUs+y9JJ/efrjAeHl/LNH6swpvM8g=="],
 
-    "@remix-run/fetch-proxy": ["@remix-run/fetch-proxy@0.8.3", "", { "dependencies": { "@remix-run/headers": "^0.21.1" } }, "sha512-FP2/0DIdnPGXMk+UAsRhYmunj3ElH2QNjuvD7VjjyWOAs9vHn7XnvfKk+qs1VDXAO5J9fkzwPQ+Y0n9FJZ8srQ=="],
+    "@remix-run/fetch-proxy": ["@remix-run/fetch-proxy@0.8.4", "", { "dependencies": { "@remix-run/headers": "^0.21.1" } }, "sha512-5Vy8EnRgkboQFpGpVL9TNUEFauh94Cq8Vh9pI1g5jQ3C5OnnMuDKtZV0xR0B7plrI3537ZDFbMRaTG8crKAenA=="],
 
-    "@remix-run/fetch-router": ["@remix-run/fetch-router@0.20.0", "", { "dependencies": { "@remix-run/route-pattern": "^0.22.1" } }, "sha512-iNjDAesu37Yf8nApAkKgKjmZBavC+AuzWK9EUmiwo+OnH7nn8ag5whyVFR4kb0LJN5CeXciFEIjX+oHG5cNeyw=="],
+    "@remix-run/fetch-router": ["@remix-run/fetch-router@0.20.1", "", { "dependencies": { "@remix-run/route-pattern": "^0.23.0" } }, "sha512-vxlIu4LHY5KyqOdlXFjJeUefUJxgc7499/cSsBl2bzhQnU5DayPHN/dklBOiG+U7GIYQMmObAinmubkwzaXyuw=="],
 
-    "@remix-run/file-storage": ["@remix-run/file-storage@0.13.6", "", { "dependencies": { "@remix-run/fs": "^0.4.5", "@remix-run/lazy-file": "^5.0.5" } }, "sha512-dXX7gcoPPWFa/041U/fCW9jHS11v8oC8UCrMRpbkyltz+tI55KvJ60oHYPUqnu75b9Ep60lZHvNviqlSn1Iv4w=="],
+    "@remix-run/file-storage": ["@remix-run/file-storage@0.13.7", "", { "dependencies": { "@remix-run/fs": "^0.4.6", "@remix-run/lazy-file": "^5.0.6" } }, "sha512-7tDgyzs1v0dQgfMt+lpbIzEVkrgrcKJLGbBeXrpJITuCeWoc0XgFfDTp6gghS3s8aWQTm5XHbgnldLoQCEU9Mw=="],
 
-    "@remix-run/file-storage-s3": ["@remix-run/file-storage-s3@0.1.3", "", { "dependencies": { "@remix-run/file-storage": "^0.13.6", "aws4fetch": "^1.0.20" } }, "sha512-15OlGiiiSJnM4KlrcCxYBqIRHAubNEy8LsBRnI/bXXzsSgNOS/gnAi9dhjkgHScLPtgr8Xf0kyO1zUl82/41dA=="],
+    "@remix-run/file-storage-s3": ["@remix-run/file-storage-s3@0.1.4", "", { "dependencies": { "@remix-run/file-storage": "^0.13.7", "aws4fetch": "^1.0.20" } }, "sha512-n1Z97PpaDIE5tOiRBJTy864ieZtWO1laqdz4pvKbr9KdfUxLRaWmk5gj+UaH7nC+e0sB3wBK9QhjfyoFuGOY6A=="],
 
-    "@remix-run/form-data-middleware": ["@remix-run/form-data-middleware@0.3.3", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.0", "@remix-run/form-data-parser": "^0.17.3" } }, "sha512-46FpwGGyjJXvH1ZioZtL8FGO14qDASqaZmnqXmeUspZ4XvtEVAiEfzcPYUnmCNzrvBSuGlgU5WqUfOQxbtXAHA=="],
+    "@remix-run/form-data-middleware": ["@remix-run/form-data-middleware@0.3.4", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.1", "@remix-run/form-data-parser": "^0.17.4" } }, "sha512-i/bnBzvXl4qkslVjy/h7r7ODuYiGJ548wDqql757p2eaZCW8h+y8T0/NXh+GcRfleBPYBxst0is6XDEHzt+I6w=="],
 
-    "@remix-run/form-data-parser": ["@remix-run/form-data-parser@0.17.3", "", { "dependencies": { "@remix-run/multipart-parser": "^0.16.3" } }, "sha512-K23ImS2P+Gl4ZEK00dEa2GAuhQJkxocvMsnF5SafcRh4aoKINUcdiCQraBDP+929c3VxnP3nUj5UYzBtGuGIIw=="],
+    "@remix-run/form-data-parser": ["@remix-run/form-data-parser@0.17.4", "", { "dependencies": { "@remix-run/multipart-parser": "^0.16.3" } }, "sha512-mqWVpD2OaJTFEW2i+M49/iWoUp2Cai6WD606/iynZ+NIlzVdkty3bbGb8g7vTjXeV/sQRmPbg3SJypgvQitvJg=="],
 
-    "@remix-run/fs": ["@remix-run/fs@0.4.5", "", { "dependencies": { "@remix-run/lazy-file": "^5.0.5", "@remix-run/mime": "^0.4.1" } }, "sha512-aruAQN2R//NQBeKg3YnovJ4JMZRmJ0pVWq3xoUMTeO16L6dCP82Al+dSizwGHy7ZavPfJwnlJHp5exTAhX5yCQ=="],
+    "@remix-run/fs": ["@remix-run/fs@0.4.6", "", { "dependencies": { "@remix-run/lazy-file": "^5.0.6", "@remix-run/mime": "^0.4.2" } }, "sha512-xxvixX/WyufRr6YrjPLGXvyE5Lzb5G/Y4tygk6McJ6nr59f3hO9w3aVc/lvsVPD7liYfM1EyMnmd4qIByJq9bg=="],
 
     "@remix-run/headers": ["@remix-run/headers@0.21.1", "", {}, "sha512-DRhRveigepAQDUIi0MrOFhpcl3/KTv/fkpIhulv7Asv1pUwM8RpY2ENjdI8lfii6Z3MEsWtYhGt6If8bi6bYpQ=="],
 
     "@remix-run/html-template": ["@remix-run/html-template@0.3.1", "", {}, "sha512-4yhaBtfh1iVC1razTr+ehu1xmKia0zvE4GWQ6JF2IRiA3kmw+DlrdNFEFqx5Wn1eXAM0vxxcJLdLD7e0XMzH5A=="],
 
-    "@remix-run/lazy-file": ["@remix-run/lazy-file@5.0.5", "", { "dependencies": { "@remix-run/mime": "^0.4.1" } }, "sha512-PhjTgR266T2qDKki6lQnlOtgZv4VB8Dqeu1sBUu2pBazgi2nZA2n7lvDpNiegKozBgGfUXS8ScdIQ6FPuNvtcw=="],
+    "@remix-run/lazy-file": ["@remix-run/lazy-file@5.0.6", "", { "dependencies": { "@remix-run/mime": "^0.4.2" } }, "sha512-jIeeqkqR+AgTEKls5WMPbiGyXhrkAJugN4ot/K9X74CLzO9uMbcFDKef7CWCfjN1s+551u+5LxNWLJx1nztuVg=="],
 
-    "@remix-run/logger-middleware": ["@remix-run/logger-middleware@0.3.3", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.0", "@remix-run/terminal": "^0.1.1" } }, "sha512-nrKhWowr3PPimgwngx3U343ohS5noBTx1jgohMVP+3M0DxrQbJNppXu2qty93XZk4XGECj+DgQhU9U1O8ARLcA=="],
+    "@remix-run/logger-middleware": ["@remix-run/logger-middleware@0.3.4", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.1", "@remix-run/terminal": "^0.1.1" } }, "sha512-hHCZKt1mzqm+pxl/TlkFnaMCSbnLRdad6G9ZWsM0V/hpNPvCYuPjL5eEHiHl8QQeio9xXVOpdefL0X6vDpwRAg=="],
 
-    "@remix-run/method-override-middleware": ["@remix-run/method-override-middleware@0.1.11", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.0" } }, "sha512-OP9yc33e3bEkjJ36YgVlUVuQcIUSLpFjjpDA7etK1qgRNE2EHBmVBR5ypqfGF2PORV0FnLvmAaeVpdz3eo/CNA=="],
+    "@remix-run/method-override-middleware": ["@remix-run/method-override-middleware@0.1.12", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.1" } }, "sha512-B4bzxpbvNKcr0cAQCWYTqYq1YFujkGP233vousmj9LjKOuz03Svn9pt9kA03Ps8ZFSoW/usTfOPJ3MckAB9BJw=="],
 
-    "@remix-run/mime": ["@remix-run/mime@0.4.1", "", {}, "sha512-n0DUUwpHiDrtHCSw6YFbjeMjajj7STqwzK9PMJkQOHbvOarfPdQdRRMkRqYPBmhu6ABzb6sAdYRSrxPx50I5VQ=="],
+    "@remix-run/mime": ["@remix-run/mime@0.4.2", "", {}, "sha512-KpZZxBYIrLsvUtt2ZdwK+E2ClVmyvW11Nej6fPgwJpohBMpbCHtR78wtCTv0vqvK5ckLZ7ks2q4pV5dMYFypiA=="],
 
     "@remix-run/multipart-parser": ["@remix-run/multipart-parser@0.16.3", "", { "dependencies": { "@remix-run/headers": "^0.21.1" } }, "sha512-XvMYPIyDTuquR7s1YF4wo4CqMPDrBkpWY0zHSa7SpX0F+t9awg7FWd5mJywc6vTn4oWeS7nQYQQarZ9CuoC/RQ=="],
 
-    "@remix-run/node-fetch-server": ["@remix-run/node-fetch-server@0.13.3", "", {}, "sha512-UfjOXed/DQteaM5VyTfqTeGpHwyL2J5aoRGY6cydip4tt1ehNNeSwuXCC7AEGE0RWBs/7bgKxYkL/B/+UDe4AA=="],
+    "@remix-run/node-fetch-server": ["@remix-run/node-fetch-server@0.14.0", "", {}, "sha512-s46HS2YuZwCJxwXIrcWdKTfIXWf2G2S20bXeYR2BqBoUkmc4RSiC+VRely6pqNvSUIio8piaI+uLN40IvoFN/A=="],
 
     "@remix-run/node-tsx": ["@remix-run/node-tsx@0.1.1", "", { "dependencies": { "get-tsconfig": "^4.13.6", "oxc-transform": "^0.121.0" } }, "sha512-k9Oi2gML1E7c1PLj+kX+Hsumkjg9tpps7+ufpy7ugsiRTe6fDfZOyEmlYOIkfR2K2Nf8D33+967EMlInm9Nvvg=="],
 
-    "@remix-run/render-middleware": ["@remix-run/render-middleware@0.1.3", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.0" } }, "sha512-wxrjRdYbiE7yT2VhCe1M7/ir4M44M6cxwnzCdxd8qVIg+i4lbFdizDR72ClDNoAQ2hPtlHDy7+2U+ufnNHUGRQ=="],
+    "@remix-run/render-middleware": ["@remix-run/render-middleware@0.1.4", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.1" } }, "sha512-v+RL5T5hDEMNjQyrV/UwODu/x6BUUkpt5EHGixXc00j74KP1g07rtPJvFeeZM6/Yq42I0Ej/4OqsMBiLDjt3dA=="],
 
-    "@remix-run/response": ["@remix-run/response@0.3.6", "", { "dependencies": { "@remix-run/headers": "^0.21.1", "@remix-run/html-template": "^0.3.1", "@remix-run/mime": "^0.4.1" } }, "sha512-WgbAXEGesrfVz449Lv1AUruT2r2t79XxkcG/cdzDZWXB/2UKcKFsVSM/tFvfmIuAtwdvhQrrnaFpnC04OfYSNA=="],
+    "@remix-run/response": ["@remix-run/response@0.3.7", "", { "dependencies": { "@remix-run/headers": "^0.21.1", "@remix-run/html-template": "^0.3.1", "@remix-run/mime": "^0.4.2" } }, "sha512-f3VWP4NNxgBt+oJfRbgqLYaMXonMdeHhbzAyLfqMzZAwe/ukUwwGoTtER2xlRPDxFlr9Tqa3NFC8PrSmp+rfmA=="],
 
-    "@remix-run/route-pattern": ["@remix-run/route-pattern@0.22.1", "", {}, "sha512-czdGJWh09Lapvcqt7Vb09KlrU2PhRJ8xQaI+AItTuD9aDJ5MAgxnS38lnys6Ll+6RJEqPiaUqTwIQhVLwFvv+w=="],
+    "@remix-run/route-pattern": ["@remix-run/route-pattern@0.23.0", "", {}, "sha512-8eZfG9owfdvC1OqWemjyIqbFTjWbKTW8RrcbppXrnv1GHMIpFOQx9Ly6F1OXNM03aK1c923JypacoRjamyfVEw=="],
 
     "@remix-run/session": ["@remix-run/session@0.4.2", "", {}, "sha512-NGzu6/gC5xD/tq40W0WqzTt4JhCdSCIwDHM1aa13JBqb4Ml/Mb0kmXqjfOe/gBYfu6AA11nRQ/BJyr+VduTodA=="],
 
-    "@remix-run/session-middleware": ["@remix-run/session-middleware@0.3.3", "", { "dependencies": { "@remix-run/cookie": "^0.5.4", "@remix-run/fetch-router": "^0.20.0", "@remix-run/session": "^0.4.2" } }, "sha512-mMY3DJNpRAdEu6TMAVV0N6kGr3UCvucfunHHOzvWwMy7QVXqIgYFfJFIzWuHiKKGVUdNyBhDAADA3e9eLNtXRA=="],
+    "@remix-run/session-middleware": ["@remix-run/session-middleware@0.3.4", "", { "dependencies": { "@remix-run/cookie": "^0.5.4", "@remix-run/fetch-router": "^0.20.1", "@remix-run/session": "^0.4.2" } }, "sha512-vFZ70F75Zj1o+UhJ9IJrPlaiFoItwGPrNTY4k5bVKpe4KdwNEat/z3HtfNG2NuBeUys8XhCE3yCT13SM50NkiQ=="],
 
     "@remix-run/session-storage-memcache": ["@remix-run/session-storage-memcache@0.1.2", "", { "dependencies": { "@remix-run/session": "^0.4.2" } }, "sha512-VIJnz+DcJFo+vM1SRKy/8kbJHefVQtGyKS+V1AOMCk8OAMGCCyS+f4ERxmu3as48T/L55oBPsTxQX+rcPchDtQ=="],
 
     "@remix-run/session-storage-redis": ["@remix-run/session-storage-redis@0.1.1", "", { "dependencies": { "@remix-run/session": "^0.4.2" }, "peerDependencies": { "redis": "^5.10.0" }, "optionalPeers": ["redis"] }, "sha512-y/dhJq5hs4rs1zCCPbPJp+i0/EBcYkwQLnwQ4mYtJbSjYIUklSqD3Z7+K8V/MJtl7B4fq8RD1m20lLjLSESMLw=="],
 
-    "@remix-run/static-middleware": ["@remix-run/static-middleware@0.4.12", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.0", "@remix-run/fs": "^0.4.5", "@remix-run/html-template": "^0.3.1", "@remix-run/mime": "^0.4.1", "@remix-run/response": "^0.3.6" } }, "sha512-ovppEYU9SdEzt7+jIZYN+ReD4LaWau2Vi98obAzgMdOfKBiP3C0ftdXhVmTBBtDq0kJdFoVi7NE/c95FpnGkwg=="],
+    "@remix-run/static-middleware": ["@remix-run/static-middleware@0.4.13", "", { "dependencies": { "@remix-run/fetch-router": "^0.20.1", "@remix-run/fs": "^0.4.6", "@remix-run/html-template": "^0.3.1", "@remix-run/mime": "^0.4.2", "@remix-run/response": "^0.3.7" } }, "sha512-32oI2hbVR+GN/sduxOZSY1WNaEasKDm7X7o79eBGG5E78dV5mi0ijGLldHfAEazyRQyqeYzvG292RWUfkFJetA=="],
 
     "@remix-run/tar-parser": ["@remix-run/tar-parser@0.7.1", "", {}, "sha512-NZKTuA66rj0zqpljWAb6v147cNu5BtRCiv8FY5kn64ZPvLmoI62Ehm2hoUh0g0wJHeCNmgS5QZg1xhw6FX67SA=="],
 
@@ -557,7 +557,7 @@
 
     "@remix-run/test": ["@remix-run/test@0.5.0", "", { "dependencies": { "@remix-run/node-tsx": "^0.1.1", "@remix-run/terminal": "^0.1.1", "es-module-lexer": "^2.0.0", "esbuild": "^0.27.1", "get-tsconfig": "^4.13.6", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magic-string": "^0.30.21", "oxc-resolver": "^11.19.1", "source-map-js": "^1.2.1", "v8-to-istanbul": "^9.3.0" }, "peerDependencies": { "playwright": "^1.60.0" }, "optionalPeers": ["playwright"], "bin": { "remix-test": "dist/cli-entry.js" } }, "sha512-jaJLJi7+YXFh4JblWe3hjqve8tkiZ1Nzsog1j6EwCEv814bHldCqBbFrajI69DUULd3nNCs3Mk3rz96lt83xYA=="],
 
-    "@remix-run/ui": ["@remix-run/ui@0.3.0", "", { "dependencies": { "@types/dom-navigation": "^1.0.7" } }, "sha512-5zWmsnrls7UPioYg5vRNK3YQam5O3GGZBPONgi50f1Si3QPIdjNQvOEN2Qj1TcY3ehtLcsGgtBbba6AsXRR85A=="],
+    "@remix-run/ui": ["@remix-run/ui@0.4.0", "", { "dependencies": { "@types/dom-navigation": "^1.0.7" } }, "sha512-0whpy2s0V5ZHsErcEPESUZ7McmKQ3Nn1Ut5j4CkQVeos5VT3e1z/+osERMywUNTo2nyeUMpEMte5bFmaoleI3g=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.12", "", { "os": "android", "cpu": "arm64" }, "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA=="],
 
@@ -1259,7 +1259,7 @@
 
     "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
 
-    "remix": ["remix@3.0.0-beta.4", "", { "dependencies": { "@remix-run/assert": "^0.3.0", "@remix-run/assets": "^0.4.3", "@remix-run/async-context-middleware": "^0.3.3", "@remix-run/auth": "^0.2.5", "@remix-run/auth-middleware": "^0.2.3", "@remix-run/cli": "^0.3.3", "@remix-run/compression-middleware": "^0.1.11", "@remix-run/cookie": "^0.5.4", "@remix-run/cop-middleware": "^0.1.6", "@remix-run/cors-middleware": "^0.1.6", "@remix-run/csrf-middleware": "^0.1.6", "@remix-run/data-schema": "^0.3.0", "@remix-run/data-table": "^0.3.0", "@remix-run/data-table-mysql": "^0.4.0", "@remix-run/data-table-postgres": "^0.4.0", "@remix-run/data-table-sqlite": "^0.5.1", "@remix-run/fetch-proxy": "^0.8.3", "@remix-run/fetch-router": "^0.20.0", "@remix-run/file-storage": "^0.13.6", "@remix-run/file-storage-s3": "^0.1.3", "@remix-run/form-data-middleware": "^0.3.3", "@remix-run/form-data-parser": "^0.17.3", "@remix-run/fs": "^0.4.5", "@remix-run/headers": "^0.21.1", "@remix-run/html-template": "^0.3.1", "@remix-run/lazy-file": "^5.0.5", "@remix-run/logger-middleware": "^0.3.3", "@remix-run/method-override-middleware": "^0.1.11", "@remix-run/mime": "^0.4.1", "@remix-run/multipart-parser": "^0.16.3", "@remix-run/node-fetch-server": "^0.13.3", "@remix-run/node-tsx": "^0.1.1", "@remix-run/render-middleware": "^0.1.3", "@remix-run/response": "^0.3.6", "@remix-run/route-pattern": "^0.22.1", "@remix-run/session": "^0.4.2", "@remix-run/session-middleware": "^0.3.3", "@remix-run/session-storage-memcache": "^0.1.2", "@remix-run/session-storage-redis": "^0.1.1", "@remix-run/static-middleware": "^0.4.12", "@remix-run/tar-parser": "^0.7.1", "@remix-run/terminal": "^0.1.1", "@remix-run/test": "^0.5.0", "@remix-run/ui": "^0.3.0" }, "peerDependencies": { "mysql2": "^3.15.3", "pg": "^8.16.3", "playwright": "^1.60.0", "redis": "^5.10.0" }, "optionalPeers": ["mysql2", "pg", "playwright", "redis"], "bin": { "remix": "dist/cli-entry.js" } }, "sha512-KT3elI5Xqbsuy17EXyAicM4aOrbReMMu4ozwRVGxe+XYu7IiZ0q4ScCHUg2MLRrazADLewbZLIODrK61LGMfwg=="],
+    "remix": ["remix@3.0.0-beta.5", "", { "dependencies": { "@remix-run/assert": "^0.3.0", "@remix-run/assets": "^0.4.4", "@remix-run/async-context-middleware": "^0.3.4", "@remix-run/auth": "^0.2.6", "@remix-run/auth-middleware": "^0.2.4", "@remix-run/cli": "^0.3.4", "@remix-run/compression-middleware": "^0.1.12", "@remix-run/cookie": "^0.5.4", "@remix-run/cop-middleware": "^0.1.7", "@remix-run/cors-middleware": "^0.1.7", "@remix-run/csrf-middleware": "^0.1.7", "@remix-run/data-schema": "^0.3.0", "@remix-run/data-table": "^0.3.0", "@remix-run/data-table-mysql": "^0.4.0", "@remix-run/data-table-postgres": "^0.4.0", "@remix-run/data-table-sqlite": "^0.5.1", "@remix-run/fetch-proxy": "^0.8.4", "@remix-run/fetch-router": "^0.20.1", "@remix-run/file-storage": "^0.13.7", "@remix-run/file-storage-s3": "^0.1.4", "@remix-run/form-data-middleware": "^0.3.4", "@remix-run/form-data-parser": "^0.17.4", "@remix-run/fs": "^0.4.6", "@remix-run/headers": "^0.21.1", "@remix-run/html-template": "^0.3.1", "@remix-run/lazy-file": "^5.0.6", "@remix-run/logger-middleware": "^0.3.4", "@remix-run/method-override-middleware": "^0.1.12", "@remix-run/mime": "^0.4.2", "@remix-run/multipart-parser": "^0.16.3", "@remix-run/node-fetch-server": "^0.14.0", "@remix-run/node-tsx": "^0.1.1", "@remix-run/render-middleware": "^0.1.4", "@remix-run/response": "^0.3.7", "@remix-run/route-pattern": "^0.23.0", "@remix-run/session": "^0.4.2", "@remix-run/session-middleware": "^0.3.4", "@remix-run/session-storage-memcache": "^0.1.2", "@remix-run/session-storage-redis": "^0.1.1", "@remix-run/static-middleware": "^0.4.13", "@remix-run/tar-parser": "^0.7.1", "@remix-run/terminal": "^0.1.1", "@remix-run/test": "^0.5.0", "@remix-run/ui": "^0.4.0" }, "peerDependencies": { "mysql2": "^3.15.3", "pg": "^8.16.3", "playwright": "^1.60.0", "redis": "^5.10.0" }, "optionalPeers": ["mysql2", "pg", "playwright", "redis"], "bin": { "remix": "dist/cli-entry.js" } }, "sha512-X3l2jLV8vQ4PQigVC1GXtvbopFlfPaP56OC1c9xNilJPw/9QN8UCZRHu43IvAeR4sdNW+j72p5AKDFbiUTrvVw=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@modelcontextprotocol/sdk": "1.26.0",
     "agents": "^0.7.6",
     "get-port": "^7.1.0",
-    "remix": "3.0.0-beta.4",
+    "remix": "3.0.0-beta.5",
     "workers-ai-provider": "^3.1.2",
     "zod": "^4.3.6"
   }

--- a/server/auth-session.ts
+++ b/server/auth-session.ts
@@ -1,4 +1,4 @@
-import { createCookie } from '@remix-run/cookie'
+import { createCookie } from 'remix/cookie'
 
 const defaultSessionMaxAgeSeconds = 60 * 60 * 24 * 7
 const rememberedSessionMaxAgeSeconds = 60 * 60 * 24 * 30


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Update Remix from 3.0.0-beta.4 to 3.0.0-beta.5, matching the current `remix@next` dist-tag.
- Refresh Bun lockfile entries for Remix-owned packages resolved by the beta.5 release.
- Replace the lone direct `@remix-run/cookie` source import with the public `remix/cookie` entrypoint so app code consistently consumes Remix through the v3 single-package surface.

## Remix beta.5 review
- Reviewed the Remix beta.5 release PR/release notes for new exports, removed exports, and package-level changes.
- Confirmed this repo does not use removed `remix/components/*` exports, removed `remix/ui` helper re-exports, `remix/node-fetch-server`, direct `remix/route-pattern` internals, `remix/fetch-proxy`, or `parseFormData()`.
- No beta.5-specific app rewrites were warranted. The only clearly beneficial scoped cleanup was switching the direct transitive cookie import to `remix/cookie`.

## Testing
- `bun install --frozen-lockfile` ✅ no changes
- `bun run lint` ✅ 0 warnings / 0 errors
- `bun run typecheck` ✅
- `bun run build` ✅
- `bun run test:unit` ✅ 4 files / 14 tests passed
- `bun run test:mcp` ✅ 1 file / 4 tests passed
- `bun run test:e2e` ✅ 19 tests passed
- PR CI on latest commit `d3c187a` ✅ `🧹 Lint`, `🧪 Typecheck`, `✅ Unit Tests`, `🧩 MCP E2E`, `🎭 E2E`, `🔎 Deploy Preview Resources`, and Cursor Bugbot all passed

## Review loop
- Requested review-agent passes on the dependency bump, lockfile resolution, beta.5 applicability, and final diff.
- Review agents found no valid blocking issues.
- PR has been marked ready for review.

## Notes
- `bun run format:check` currently fails on pre-existing files outside this dependency update (`docs/agents/testing-principles.md`, `mcp/mcp-server-e2e.test.ts`, `mock-servers/resend/resend-mock.test.ts`, `test-support/process-utils.ts`, `worker/ai-runtime.test.ts`, `worker/mcp-auth.test.ts`, `worker/oauth-handlers.ts`). I left those unrelated formatting changes untouched.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2344c701-5e36-4871-9584-12c591f738f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2344c701-5e36-4871-9584-12c591f738f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

