### PR TITLE
Add navigation progress bar

### DIFF
--- a/client/app.tsx
+++ b/client/app.tsx
@@ -11,6 +11,7 @@ import {
 	type SessionInfo,
 	type SessionStatus,
 } from './session.ts'
+import { NavigationProgress } from './navigation-progress.tsx'
 import { SessionProvider } from './session-context.tsx'
 import { buildAuthLink } from './auth-links.ts'
 import { colors, mq, spacing, typography } from './styles/tokens.ts'
@@ -200,6 +201,7 @@ export function App(handle: Handle<AppProps>) {
 					) : null}
 				</nav>
 				<SessionProvider session={session}>
+					<NavigationProgress />
 					<Router
 						loaders={clientRouteLoaders}
 						routes={clientRoutes}

--- a/client/client-router.tsx
+++ b/client/client-router.tsx
@@ -85,9 +85,45 @@ const routeLoaderMatchers = new WeakMap<
 let routerInitialized = false
 let activeRouteLoaders: Record<string, RouteLoader> | null = null
 let pendingProgrammaticNavigationPath: string | null = null
+let pendingProgrammaticNavigationSuppressStart = false
+let navigationAbortController: AbortController | null = null
 
 function notify() {
 	routerEvents.dispatchEvent(new Event('navigate'))
+}
+
+function dispatchNavigationStart() {
+	routerEvents.dispatchEvent(
+		new CustomEvent('navigationstart', {
+			detail: { location: getCurrentPathWithSearchAndHash() },
+		}),
+	)
+}
+
+function dispatchNavigationEnd(location = getCurrentPathWithSearchAndHash()) {
+	routerEvents.dispatchEvent(
+		new CustomEvent('navigationend', {
+			detail: { location },
+		}),
+	)
+}
+
+function beginNavigation(options: { suppressStart?: boolean } = {}) {
+	navigationAbortController?.abort()
+	const controller = new AbortController()
+	navigationAbortController = controller
+	if (!options.suppressStart) {
+		dispatchNavigationStart()
+	}
+	return controller
+}
+
+function finishNavigation(controller: AbortController, location?: string) {
+	if (navigationAbortController !== controller) return
+	navigationAbortController = null
+	if (!controller.signal.aborted) {
+		dispatchNavigationEnd(location)
+	}
 }
 
 function getNavigationApi() {
@@ -300,9 +336,13 @@ function getPathWithSearchAndHashFromUrl(url: URL) {
 }
 
 function consumeProgrammaticNavigation(path: string) {
-	if (pendingProgrammaticNavigationPath !== path) return false
+	if (pendingProgrammaticNavigationPath !== path) {
+		return { matched: false, suppressStart: false }
+	}
+	const suppressStart = pendingProgrammaticNavigationSuppressStart
 	pendingProgrammaticNavigationPath = null
-	return true
+	pendingProgrammaticNavigationSuppressStart = false
+	return { matched: true, suppressStart }
 }
 
 async function preloadRouteData(destination: URL, signal: AbortSignal) {
@@ -333,10 +373,9 @@ async function preloadAndCommitNavigationData(
 	signal: AbortSignal,
 ) {
 	try {
-		return commitRouteLoaderResult(
-			destination,
-			await preloadRouteData(destination, signal),
-		)
+		const result = await preloadRouteData(destination, signal)
+		if (signal.aborted) return false
+		return commitRouteLoaderResult(destination, result)
 	} catch (error) {
 		if (signal.aborted) return false
 		markNavigationDataStale(getPathWithSearchAndHashFromUrl(destination))
@@ -345,24 +384,37 @@ async function preloadAndCommitNavigationData(
 	}
 }
 
-async function navigateWithRefreshForSamePath(destination: URL) {
+async function navigateWithRefreshForSamePath(
+	destination: URL,
+	options: { signal?: AbortSignal; suppressStart?: boolean } = {},
+) {
 	const path = getPathWithSearchAndHashFromUrl(destination)
 	if (path === getCurrentPathWithSearchAndHash()) {
+		const controller = options.signal
+			? null
+			: beginNavigation({ suppressStart: options.suppressStart })
 		const redirected = await preloadAndCommitNavigationData(
 			destination,
-			new AbortController().signal,
+			options.signal ?? controller?.signal ?? new AbortController().signal,
 		)
 		if (!redirected) notify()
+		if (controller) {
+			finishNavigation(controller, path)
+		}
 		return
 	}
-	navigate(destination.toString())
+	navigate(destination.toString(), { suppressStart: options.suppressStart })
 }
 
-async function submitPostFormThroughRouter(details: FormSubmitDetails) {
+async function submitPostFormThroughRouter(
+	details: FormSubmitDetails,
+	signal?: AbortSignal,
+) {
 	const init: RequestInit = {
 		method: details.method.toUpperCase(),
 		credentials: 'include',
 		redirect: 'follow',
+		signal,
 	}
 
 	if (details.enctype === 'application/x-www-form-urlencoded') {
@@ -400,8 +452,24 @@ async function submitFormThroughRouter(details: FormSubmitDetails) {
 		return
 	}
 
-	const destination = await submitPostFormThroughRouter(details)
-	await navigateWithRefreshForSamePath(destination)
+	const controller = beginNavigation()
+	try {
+		const destination = await submitPostFormThroughRouter(
+			details,
+			controller.signal,
+		)
+		if (controller.signal.aborted) return
+		await navigateWithRefreshForSamePath(destination, {
+			signal: controller.signal,
+			suppressStart: true,
+		})
+		finishNavigation(controller, getPathWithSearchAndHashFromUrl(destination))
+	} catch (error) {
+		if (!controller.signal.aborted) {
+			console.error('Router form submit failed', error)
+			finishNavigation(controller)
+		}
+	}
 }
 
 function handleDocumentSubmit(event: Event) {
@@ -416,16 +484,13 @@ function handleDocumentSubmit(event: Event) {
 	if (!details) return
 
 	event.preventDefault()
-	void submitFormThroughRouter(details).catch((error: unknown) => {
-		console.error('Router form submit failed', error)
-	})
+	void submitFormThroughRouter(details)
 }
 
 function shouldInterceptNavigationEvent(event: RouterNavigateEvent) {
 	if (typeof window === 'undefined') return false
 	if (!event.canIntercept) return false
 	if (event.downloadRequest !== null) return false
-	if (event.hashChange) return false
 	if (event.navigationType === 'reload') return false
 
 	const destination = new URL(event.destination.url, window.location.href)
@@ -436,6 +501,22 @@ function shouldInterceptNavigationEvent(event: RouterNavigateEvent) {
 function handleNavigationEvent(event: RouterNavigateEvent) {
 	if (!shouldInterceptNavigationEvent(event)) return
 
+	if (event.hashChange) {
+		event.intercept({
+			handler() {
+				const controller = beginNavigation()
+				notify()
+				finishNavigation(
+					controller,
+					getPathWithSearchAndHashFromUrl(
+						new URL(event.destination.url, window.location.href),
+					),
+				)
+			},
+		})
+		return
+	}
+
 	const { form } = getFormForSourceElement(event.sourceElement)
 	if (form) {
 		// Keep form submissions on the submit-handler path until precommit
@@ -444,22 +525,37 @@ function handleNavigationEvent(event: RouterNavigateEvent) {
 	}
 	const destination = new URL(event.destination.url, window.location.href)
 	const nextPath = getPathWithSearchAndHashFromUrl(destination)
-	const isProgrammaticNavigation = consumeProgrammaticNavigation(nextPath)
+	const programmaticNavigation = consumeProgrammaticNavigation(nextPath)
+	const controller = programmaticNavigation.matched
+		? beginNavigation({
+				suppressStart: programmaticNavigation.suppressStart,
+			})
+		: beginNavigation()
 
 	event.intercept({
 		async handler() {
-			if (isProgrammaticNavigation) {
+			if (programmaticNavigation.matched) {
 				notify()
+				finishNavigation(controller, nextPath)
 				return
 			}
-			const controller = new AbortController()
 			const redirected = await preloadAndCommitNavigationData(
 				destination,
 				controller.signal,
 			)
-			if (!redirected) notify()
+			if (controller.signal.aborted) return
+			if (!redirected) {
+				notify()
+			}
+			finishNavigation(controller, nextPath)
 		},
 	})
+}
+
+function handlePopstate() {
+	const controller = beginNavigation()
+	notify()
+	finishNavigation(controller)
 }
 
 function ensureRouter() {
@@ -474,7 +570,7 @@ function ensureRouter() {
 		return
 	}
 
-	window.addEventListener('popstate', notify)
+	window.addEventListener('popstate', handlePopstate)
 	document.addEventListener('click', handleDocumentClick)
 }
 
@@ -506,7 +602,10 @@ function getCurrentPathWithSearchAndHash() {
 	return `${window.location.pathname}${window.location.search}${window.location.hash}`
 }
 
-export function navigate(to: string) {
+export function navigate(
+	to: string,
+	options: { suppressStart?: boolean } = {},
+) {
 	if (typeof window === 'undefined') return
 	const destination = new URL(to, window.location.href)
 	if (destination.origin !== window.location.origin) {
@@ -520,12 +619,15 @@ export function navigate(to: string) {
 	const navigationApi = getNavigationApi()
 	if (navigationApi) {
 		pendingProgrammaticNavigationPath = nextPath
+		pendingProgrammaticNavigationSuppressStart = options.suppressStart === true
 		navigationApi.navigate(nextPath)
 		return
 	}
 
+	const controller = beginNavigation({ suppressStart: options.suppressStart })
 	window.history.pushState({}, '', nextPath)
 	notify()
+	finishNavigation(controller, nextPath)
 }
 
 type RouterHandle = Pick<Handle, 'context' | 'signal' | 'update'> & {

--- a/client/client-router.tsx
+++ b/client/client-router.tsx
@@ -401,9 +401,10 @@ async function navigateWithRefreshForSamePath(
 		if (controller) {
 			finishNavigation(controller, path)
 		}
-		return
+		return true
 	}
 	navigate(destination.toString(), { suppressStart: options.suppressStart })
+	return false
 }
 
 async function submitPostFormThroughRouter(
@@ -459,11 +460,16 @@ async function submitFormThroughRouter(details: FormSubmitDetails) {
 			controller.signal,
 		)
 		if (controller.signal.aborted) return
-		await navigateWithRefreshForSamePath(destination, {
-			signal: controller.signal,
-			suppressStart: true,
-		})
-		finishNavigation(controller, getPathWithSearchAndHashFromUrl(destination))
+		const completedNavigation = await navigateWithRefreshForSamePath(
+			destination,
+			{
+				signal: controller.signal,
+				suppressStart: true,
+			},
+		)
+		if (completedNavigation) {
+			finishNavigation(controller, getPathWithSearchAndHashFromUrl(destination))
+		}
 	} catch (error) {
 		if (!controller.signal.aborted) {
 			console.error('Router form submit failed', error)

--- a/client/navigation-progress.tsx
+++ b/client/navigation-progress.tsx
@@ -1,0 +1,185 @@
+import { addEventListeners, css, type Handle } from 'remix/ui'
+import { routerEvents } from './client-router.tsx'
+import { colors } from './styles/tokens.ts'
+
+// Spin-delay semantics (https://npm.im/spin-delay): the bar only appears if a
+// navigation is still pending after `showDelayMs`, and once shown it stays
+// visible for at least `minShowDurationMs` so fast completions never flash.
+const showDelayMs = 150
+const minShowDurationMs = 200
+const completePauseMs = 80
+const trickleIntervalMs = 200
+const trickleIncrement = 4
+const maxTrickleProgress = 90
+const fadeDurationMs = 200
+
+export function NavigationProgress(handle: Handle) {
+	let visible = false
+	let progress = 0
+	let opacity = 0
+	// Boolean, not a counter: navigations are latest-wins and a superseded
+	// (aborted) navigation never dispatches its own `navigationend`, so the
+	// winning navigation's end event must clear the pending state outright.
+	let navigationPending = false
+	let shownAt = 0
+	let showTimeoutId: ReturnType<typeof globalThis.setTimeout> | null = null
+	let trickleIntervalId: ReturnType<typeof globalThis.setInterval> | null = null
+	let completeTimeoutId: ReturnType<typeof globalThis.setTimeout> | null = null
+	let fadeTimeoutId: ReturnType<typeof globalThis.setTimeout> | null = null
+	let resetTimeoutId: ReturnType<typeof globalThis.setTimeout> | null = null
+
+	function clearShowTimeout() {
+		if (showTimeoutId === null) return
+		globalThis.clearTimeout(showTimeoutId)
+		showTimeoutId = null
+	}
+
+	function clearTrickleInterval() {
+		if (trickleIntervalId === null) return
+		globalThis.clearInterval(trickleIntervalId)
+		trickleIntervalId = null
+	}
+
+	function clearCompletionTimers() {
+		if (completeTimeoutId !== null) {
+			globalThis.clearTimeout(completeTimeoutId)
+			completeTimeoutId = null
+		}
+		if (fadeTimeoutId !== null) {
+			globalThis.clearTimeout(fadeTimeoutId)
+			fadeTimeoutId = null
+		}
+		if (resetTimeoutId !== null) {
+			globalThis.clearTimeout(resetTimeoutId)
+			resetTimeoutId = null
+		}
+	}
+
+	function clearTimers() {
+		clearShowTimeout()
+		clearTrickleInterval()
+		clearCompletionTimers()
+	}
+
+	function startTrickle() {
+		clearTrickleInterval()
+		trickleIntervalId = globalThis.setInterval(() => {
+			if (progress >= maxTrickleProgress) return
+			progress = Math.min(maxTrickleProgress, progress + trickleIncrement)
+			handle.update()
+		}, trickleIntervalMs)
+	}
+
+	function scheduleShow() {
+		clearShowTimeout()
+		showTimeoutId = globalThis.setTimeout(() => {
+			showTimeoutId = null
+			if (!navigationPending) return
+			visible = true
+			shownAt = Date.now()
+			opacity = 1
+			if (progress === 0) progress = 8
+			startTrickle()
+			handle.update()
+		}, showDelayMs)
+	}
+
+	function onNavigationStart() {
+		navigationPending = true
+		clearCompletionTimers()
+		if (!visible) {
+			scheduleShow()
+			return
+		}
+		opacity = 1
+		if (progress >= 100) progress = 8
+		startTrickle()
+		handle.update()
+	}
+
+	function completeAndFadeOut() {
+		clearTrickleInterval()
+		progress = 100
+		opacity = 1
+		handle.update()
+
+		fadeTimeoutId = globalThis.setTimeout(() => {
+			fadeTimeoutId = null
+			opacity = 0
+			handle.update()
+			resetTimeoutId = globalThis.setTimeout(() => {
+				resetTimeoutId = null
+				visible = false
+				progress = 0
+				handle.update()
+			}, fadeDurationMs)
+		}, completePauseMs)
+	}
+
+	function onNavigationEnd() {
+		if (!navigationPending) return
+		navigationPending = false
+
+		clearShowTimeout()
+
+		// Fast navigations that finished before the show delay stay invisible;
+		// completing the bar for them would cause the flash the delay avoids.
+		if (!visible) {
+			clearTrickleInterval()
+			progress = 0
+			return
+		}
+
+		const remainingShowMs = Math.max(
+			0,
+			minShowDurationMs - (Date.now() - shownAt),
+		)
+		if (remainingShowMs === 0) {
+			completeAndFadeOut()
+			return
+		}
+		completeTimeoutId = globalThis.setTimeout(() => {
+			completeTimeoutId = null
+			completeAndFadeOut()
+		}, remainingShowMs)
+	}
+
+	if (typeof document !== 'undefined') {
+		addEventListeners(routerEvents, handle.signal, {
+			navigationstart: onNavigationStart,
+			navigationend: onNavigationEnd,
+		})
+		handle.signal.addEventListener('abort', clearTimers)
+	}
+
+	return () => {
+		if (typeof document === 'undefined' || !visible) return null
+
+		return (
+			<div
+				aria-hidden="true"
+				data-navigation-progress="true"
+				mix={css({
+					position: 'fixed',
+					top: 0,
+					left: 0,
+					width: '100%',
+					height: '3px',
+					zIndex: 9999,
+					pointerEvents: 'none',
+					backgroundColor: 'transparent',
+				})}
+			>
+				<div
+					mix={css({
+						height: '100%',
+						width: `${progress}%`,
+						backgroundColor: colors.primary,
+						opacity,
+						transition: `width 200ms ease-out, opacity ${fadeDurationMs}ms ease-out`,
+					})}
+				/>
+			</div>
+		)
+	}
+}

--- a/e2e/account.spec.ts
+++ b/e2e/account.spec.ts
@@ -65,3 +65,24 @@ test('logs out from the account page', async ({ page }) => {
 	)
 	expect(markerAfterLogout).toBe(marker)
 })
+
+test('shows navigation progress during slow logout redirect', async ({ page }) => {
+	await page.goto('/login')
+	await page.getByLabel('Email').fill(testUser.email)
+	await page.getByLabel('Password').fill(testUser.password)
+	await page.getByRole('button', { name: 'Sign in' }).click()
+	await expect(page).toHaveURL(/\/account$/)
+
+	await page.route('**/logout', async (route) => {
+		await new Promise((resolve) => setTimeout(resolve, 350))
+		await route.continue()
+	})
+
+	await page.getByRole('button', { name: 'Log out' }).click()
+
+	const progress = page.locator('[data-navigation-progress="true"]')
+	await expect(progress).toBeVisible()
+	await expect(page).toHaveURL(/\/login$/)
+	await expect(page.getByRole('link', { name: 'Login' })).toBeVisible()
+	await expect(progress).toHaveCount(0)
+})

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -17,6 +17,25 @@ test('loads chat page when authenticated', async ({ page, login }) => {
 	).toHaveCount(0)
 })
 
+test('shows navigation progress during slow route navigation', async ({
+	page,
+	login,
+}) => {
+	await login()
+	await page.goto('/account')
+	await page.route('**/chat-threads*', async (route) => {
+		await new Promise((resolve) => setTimeout(resolve, 350))
+		await route.continue()
+	})
+
+	await page.getByRole('link', { name: 'Chat' }).click()
+
+	const progress = page.locator('[data-navigation-progress="true"]')
+	await expect(progress).toBeVisible()
+	await expect(page).toHaveURL(/\/chat$/)
+	await expect(progress).toHaveCount(0)
+})
+
 test('creates and deletes chat threads when authenticated', async ({
 	page,
 	login,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add Kody-style router lifecycle events: `navigationstart` and `navigationend` for loader-backed navigation, form POST redirect chains, programmatic navigation, and instant hash/popstate paths.
- Add latest-wins abort semantics so superseded loader/form navigations do not emit stale completion events.
- Mount a root-level `NavigationProgress` component with spin-delay timing, trickle progress, minimum visible duration, and fade-out.
- Keep form POST redirect chains pending until the follow-up navigation completes.
- Add E2E coverage that delays the chat route loader and logout form redirect to verify the progress bar appears and clears.

## Walkthrough
<a href="https://cursor.com/agents/bc-019f3f0c-a33f-722a-a17f-c265f08fbcf6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnavigation-progress-bar-demo.mp4"><img src="https://cursor.com/artifacts/c/art-6b735fa0-c25c-4e5f-8590-c95d3ae9b32b" alt="navigation-progress-bar-demo.mp4" /></a>

## Testing
- `bun run typecheck`
- `bun run lint`
- `bun run test:unit`
- `bun run build`
- `bun tools/prepare-e2e-env.ts && bunx playwright test e2e/account.spec.ts -g "navigation progress" e2e/chat.spec.ts -g "navigation progress"`
- `bun run test:e2e`
- Manual/headed browser walkthrough showing the top progress bar during delayed Chat route loading.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3f0c-a33f-722a-a17f-c265f08fbcf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3f0c-a33f-722a-a17f-c265f08fbcf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

